### PR TITLE
Release 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ Save the appropriate .bin file and go to [https://web.esphome.io/](https://web.e
 
 ### Full YAML file
 
-Configuration files reference other packages files, making for a very modular configuration, but requires looking at multiple files to see the entire picture.
-
 The `full_config` folder contains a single yaml file per model that contains the full standalone configuration, created by the `esphome config` command.  This adds in all of the optional parameters, so is much longer than the minimum configuration, but the single file contains all needed information to be completely independent from this repo.
 
 Copy the full config file to your personal ESPhome config file and customize as desired, then install to your device.
@@ -118,16 +116,19 @@ wifi:
   password: 123456123456
 ```
 
-Several packages are available in the `packages` folder that can be added or removed as needed.  For example, the display package includes configuration for multiple pages of information that can be enabled or disabled, or you may wish to change to the package that has a single page to avoid extra switches in HomeAssistant or if you know you won't be using the other pages and want to save on flash memory space.
-
-### Modification
+## Modification
 
 #### Using local packages
 
 By default, packages are referencing this GitHub repository, allowing you to do a new Install from ESPHome dashboard to get the latest modifications without downloading other files, but does require an Internet connection.  If you wish to have more control over modifications or only reference local files, copy the `packages` folder to your local ESPHome folder and replace `github://MallocArray/airgradient_esphome/packages` with `!include packages`
 
-> Example: `board: github://MallocArray/airgradient_esphome/packages/sensor_s8.yaml`
-> becomes `board: !include packages/sensor_s8.yaml`
+> Example:
+>
+> `board: github://MallocArray/airgradient_esphome/packages/sensor_s8.yaml`
+>
+> becomes
+>
+> `board: !include packages/sensor_s8.yaml`
 
 #### Using Extend feature
 
@@ -155,7 +156,7 @@ MQTT support has been mentioned in the AirGradient forums several times.  ESPHom
 
 Several more features are planned to be added to this repo
 
-- [ ] Support for Open Air without CO2 sensor
+- [ ] Support for Open Air without CO2 sensor (Model: O-1PPT)
 - [ ] Explore options for disabling display/LED during certain times (May be differed to HomeAssistant Automations)
 - [ ] Standardize font on AirGradient Basic display to match Pro
 - [ ] Reduce number of fonts used in the multi_page package

--- a/README.md
+++ b/README.md
@@ -162,8 +162,7 @@ Several more features are planned to be added to this repo
   - [ ] Open Sans displays a consistent height, but some characters, such as F and 0 are mismatched, the left side is double line thick while right is single line
   - [ ] Poppins Light is consistent thickness, but numbers are taller than letters, giving a mismatched height
 - [ ] Add GitHub actions to automatically build updated .bin files as needed
-
-* [X] Add support for esp32_improv and improv_serial (improv_serial not supported with this board and used pins.  esp32_improv uses 30% of available flash memory and is nearly full)
-  * [X] [https://esphome.io/guides/creators.html](https://esphome.io/guides/creators.html "https://esphome.io/guides/creators.html")
-* [X] Add support for dashboard_import and project information
-  * [X] [https://esphome.io/guides/creators.html](https://esphome.io/guides/creators.html "https://esphome.io/guides/creators.html")
+- [X] Add support for esp32_improv and improv_serial (improv_serial not supported with this board and used pins.  esp32_improv uses 30% of available flash memory and is nearly full)
+  - [X] [https://esphome.io/guides/creators.html](https://esphome.io/guides/creators.html "https://esphome.io/guides/creators.html")
+- [X] Add support for dashboard_import and project information
+  - [X] [https://esphome.io/guides/creators.html](https://esphome.io/guides/creators.html "https://esphome.io/guides/creators.html")

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Copy the .yaml file from the main folder for your model and place it in the `con
 
 > Note: by default ESPHome only syncs remote repositories that the packages are referencing once per day, so if changes are made to the repository, you may not get the updated config for up to 1 day after it is published.  You can remove the contents of the folder config/.esphome/packages to force it to update sooner
 
-> Note: setting `add_mac_suffix: "true"` allows for multiple devices on your network at the same time and report as unique entries even if your `name:` field is duplicated, but it can cause ESPHome to not detect devices as Online after installing, since ESPHome is looking for only the `devicename:` field and the actual device name has the MAC address added to the end
+> Note: setting `add_mac_suffix: "true"` allows for multiple devices on your network at the same time and report as unique entries even if your `name:` field is duplicated, but it can cause ESPHome to not detect devices as Online after installing, since ESPHome is looking for only the `name:` field and the actual device name has the MAC address added to the end
 >
-> One way to resolve this is to change `add_mac_suffix: "false"` so the devicename will match exactly.  If you have multiple devices, make sure to change the `name: `field to be unique for each device
+> One way to resolve this is to change `add_mac_suffix: "false"` so the device name will match exactly.  If you have multiple devices, make sure to change the `name: `field to be unique for each device
 >
 > Another alternative is to add a static IP to the wifi configuration and configure ESPHome to ping the device by IP instead of hostname
 >
@@ -120,15 +120,14 @@ wifi:
 
 #### Using local packages
 
-By default, packages are referencing this GitHub repository, allowing you to do a new Install from ESPHome dashboard to get the latest modifications without downloading other files, but does require an Internet connection.  If you wish to have more control over modifications or only reference local files, copy the `packages` folder to your local ESPHome folder and replace `github://MallocArray/airgradient_esphome/packages` with `!include packages`
+By default, packages are referencing this GitHub repository, allowing you to do a new Install from ESPHome dashboard to get the latest modifications without downloading other files, but does require an Internet connection.  If you wish to have more control over modifications or only reference local files, copy the `packages` folder to your local ESPHome folder in a `packages` subfolder and replace `github://MallocArray/airgradient_esphome/packages `with `!include packages`
 
-> Example:
->
-> `board: github://MallocArray/airgradient_esphome/packages/sensor_s8.yaml`
->
-> becomes
->
-> `board: !include packages/sensor_s8.yaml`
+```yaml
+# Example
+board: github://MallocArray/airgradient_esphome/packages/sensor_s8.yaml
+# becomes
+board: !include packages/sensor_s8.yaml
+```
 
 #### Using Extend feature
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # AirGradient ESPHome Configurations
 
-[toc]
-
 ESPHome yaml files for AirGradient devices to maintain the research and accuracy of AirGradient sensors, while also gaining the benefits of ESPHome/HomeAssistant for easy to use switches, buttons, configurations, and dashboards.  Maintains the ability to also send data to the AirGradient Dashboard, which can also be disabled/removed to keep all data local	.
 
 ## Breaking Changes
@@ -65,9 +63,9 @@ Copy the .yaml file from the main folder for your model and place it in the `con
 
 > Note: by default ESPHome only syncs remote repositories that the packages are referencing once per day, so if changes are made to the repository, you may not get the updated config for up to 1 day after it is published.  You can remove the contents of the folder config/.esphome/packages to force it to update sooner
 
-> Note: setting `add_mac_suffix: "true"` allows for multiple devices on your network at the same time and report as unique entries, but it can cause ESPHome to not detect devices as Online after installing, since ESPHome is looking for only the `devicename:` field and the actual device name has the MAC address added to the end.
+> Note: setting `add_mac_suffix: "true"` allows for multiple devices on your network at the same time and report as unique entries even if your `name:` field is duplicated, but it can cause ESPHome to not detect devices as Online after installing, since ESPHome is looking for only the `devicename:` field and the actual device name has the MAC address added to the end
 >
-> One way to resolve this is to change `add_mac_suffix: "false"` so the devicename will match exactly.  If you have multiple devices, make sure to change the `devicename: `field to be unique for each device
+> One way to resolve this is to change `add_mac_suffix: "false"` so the devicename will match exactly.  If you have multiple devices, make sure to change the `name: `field to be unique for each device
 >
 > Another alternative is to add a static IP to the wifi configuration and configure ESPHome to ping the device by IP instead of hostname
 >
@@ -85,12 +83,6 @@ Copy the .yaml file from the main folder for your model and place it in the `con
 >     subnet: 255.255.255.0
 >     dns1: 192.168.1.1
 > ```
-
-#### Using local packages
-
-By default, packages are referencing this GitHub repository, allowing you to do a new Install from ESPHome dashboard to get the latest modifications without downloading other files, but does require an Internet connection.  If you wish to have more control over modifications or only reference local files, copy the `packages` folder to your local ESPHome folder and replace `github://MallocArray/airgradient_esphome/packages` with `!include packages`
-
-> Example: `board: github://MallocArray/airgradient_esphome/packages/sensor_s8.yaml` becomes `board: !include packages/sensor_s8.yaml`
 
 ### ESPHome Web install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AirGradient ESPHome Configurations
 
-ESPHome yaml files for AirGradient devices to maintain the research and accuracy of AirGradient sensors, while also gaining the benefits of ESPHome/HomeAssistant for easy to use switches, buttons, configurations, and dashboards.  Maintains the ability to also send data to the AirGradient Dashboard, which can also be disabled/removed to keep all data local	.
+ESPHome yaml files for AirGradient devices to maintain the research and accuracy of AirGradient sensors, while also gaining the benefits of ESPHome/HomeAssistant for easy to use switches, buttons, configurations, and dashboards.  Maintains the ability to also send data to the AirGradient Dashboard, which can also be disabled/removed to keep all data local.
 
 ## Breaking Changes
 

--- a/airgradient-basic.yaml
+++ b/airgradient-basic.yaml
@@ -3,10 +3,10 @@
 # https://www.airgradient.com/open-airgradient/instructions/overview/
 
 substitutions:
-  devicename: "ag-basic"
-  friendly_devicename: "AG Basic"
-  ag_esphome_config_version: 1.0.0
-  add_mac_suffix: "true"  # Must have quotes around value
+  name: "ag-basic"
+  friendly_name: "AG Basic"
+  config_version: 2.0.0
+  name_add_mac_suffix: "false"  # Must have quotes around value
 
 # Enable Home Assistant API
 api:  # Add encryption key as desired
@@ -16,6 +16,10 @@ ota:  # Add password as desired
 wifi:
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
+
+dashboard_import:
+  package_import_url: github://MallocArray/airgradient_esphome/airgradient-basic.yaml
+  import_full_config: false
 
 packages:
   board: github://MallocArray/airgradient_esphome/packages/airgradient_d1_mini_board.yaml

--- a/airgradient-one.yaml
+++ b/airgradient-one.yaml
@@ -2,10 +2,10 @@
 # https://www.airgradient.com/open-airgradient/instructions/overview/
 
 substitutions:
-  devicename: "ag-one"
-  friendly_devicename: "AG One"
-  ag_esphome_config_version: 1.0.0
-  add_mac_suffix: "true"  # Must have quotes around value
+  name: "ag-one"
+  friendly_name: "AG One"
+  config_version: 2.0.0
+  name_add_mac_suffix: "false"  # Must have quotes around value
 
 # Enable Home Assistant API
 api:  # Add encryption key as desired
@@ -15,6 +15,10 @@ ota:  # Add password as desired
 wifi:
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
+
+dashboard_import:
+  package_import_url: github://MallocArray/airgradient_esphome/airgradient-one.yaml
+  import_full_config: false
 
 packages:
   board: github://MallocArray/airgradient_esphome/packages/airgradient_esp32-c3_board.yaml

--- a/airgradient-open-air-o-1pst.yaml
+++ b/airgradient-open-air-o-1pst.yaml
@@ -3,10 +3,10 @@
 # https://www.airgradient.com/open-airgradient/instructions/overview/
 
 substitutions:
-  devicename: "ag-open-air-o-1pst"
-  friendly_devicename: "AG Open Air O-1PST"
-  ag_esphome_config_version: 1.0.0
-  add_mac_suffix: "true"  # Must have quotes around value
+  name: "ag-open-air-o-1pst"
+  friendly_name: "AG Open Air O-1PST"
+  config_version: 2.0.0
+  name_add_mac_suffix: "false"  # Must have quotes around value
 
 # Enable Home Assistant API
 api:  # Add encryption key as desired
@@ -16,6 +16,10 @@ ota:  # Add password as desired
 wifi:
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
+
+dashboard_import:
+  package_import_url: github://MallocArray/airgradient_esphome/airgradient-open-air-o-1pst.yaml
+  import_full_config: false
 
 packages:
   board: github://MallocArray/airgradient_esphome/packages/airgradient_esp32-c3_board.yaml

--- a/airgradient-pro.yaml
+++ b/airgradient-pro.yaml
@@ -2,10 +2,10 @@
 # https://www.airgradient.com/open-airgradient/instructions/overview/
 
 substitutions:
-  devicename: "ag-pro"
-  friendly_devicename: "AG Pro"
-  ag_esphome_config_version: 1.0.0
-  add_mac_suffix: "true"  # Must have quotes around value
+  name: "ag-pro"
+  friendly_name: "AG Pro"
+  config_version: 2.0.0
+  name_add_mac_suffix: "false"  # Must have quotes around value
 
 # Enable Home Assistant API
 api:
@@ -15,6 +15,10 @@ ota:
 wifi:
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
+
+dashboard_import:
+  package_import_url: github://MallocArray/airgradient_esphome/airgradient-pro.yaml
+  import_full_config: false
 
 packages:
   board: github://MallocArray/airgradient_esphome/packages/airgradient_d1_mini_board.yaml

--- a/packages/airgradient_api_d1_mini.yaml
+++ b/packages/airgradient_api_d1_mini.yaml
@@ -30,7 +30,7 @@ switch:
   - platform: template
     name: "Upload to AirGradient Dashboard"
     id: upload_airgradient
-    restore_mode: RESTORE_DEFAULT_ON
+    restore_mode: RESTORE_DEFAULT_OFF
     optimistic: True
 
 esphome:

--- a/packages/airgradient_api_d1_mini_no_sgp41.yaml
+++ b/packages/airgradient_api_d1_mini_no_sgp41.yaml
@@ -28,7 +28,7 @@ switch:
   - platform: template
     name: "Upload to AirGradient Dashboard"
     id: upload_airgradient
-    restore_mode: RESTORE_DEFAULT_ON
+    restore_mode: RESTORE_DEFAULT_OFF
     optimistic: True
 
 esphome:

--- a/packages/airgradient_api_esp32-c3.yaml
+++ b/packages/airgradient_api_esp32-c3.yaml
@@ -30,7 +30,7 @@ switch:
   - platform: template
     name: "Upload to AirGradient Dashboard"
     id: upload_airgradient
-    restore_mode: RESTORE_DEFAULT_ON
+    restore_mode: RESTORE_DEFAULT_OFF
     optimistic: True
 
 esphome:

--- a/packages/airgradient_d1_mini_board.yaml
+++ b/packages/airgradient_d1_mini_board.yaml
@@ -1,12 +1,13 @@
 
 esphome:
-  name: "${devicename}"
-  friendly_name: "${friendly_devicename}"
-  name_add_mac_suffix: ${add_mac_suffix}  # Set to false if you don't want part of the MAC address in the name
+  name: "${name}"
+  friendly_name: "${friendly_name}"
+  name_add_mac_suffix: ${name_add_mac_suffix}  # Set to false if you don't want part of the MAC address in the name
+
   project:
     name: mallocarray.airgradient
-    version: "$ag_esphome_config_version"
-  min_version: 2023.7.0
+    version: "$config_version"
+  min_version: 2023.12.0
 
 esp8266:
   board: d1_mini
@@ -41,3 +42,9 @@ i2c:
   sda: D2
   scl: D1
   frequency: 400kHz  # 400kHz eliminates warnings about components taking a long time other than SGP40 component: https://github.com/esphome/issues/issues/4717
+
+button:
+  - platform: factory_reset
+    disabled_by_default: true
+    name: "Factory Reset ESP"
+    id: factory_reset_all

--- a/packages/airgradient_esp32-c3_board.yaml
+++ b/packages/airgradient_esp32-c3_board.yaml
@@ -1,15 +1,20 @@
 
 esphome:
-  name: "${devicename}"
-  friendly_name: "${friendly_devicename}"
-  name_add_mac_suffix: ${add_mac_suffix}  # Set to false if you don't want part of the MAC address in the name
+  name: "${name}"
+  friendly_name: "${friendly_name}"
+  name_add_mac_suffix: ${name_add_mac_suffix}  # Set to false if you don't want part of the MAC address in the name
+
   project:
     name: mallocarray.airgradient
-    version: "$ag_esphome_config_version"
-  min_version: 2023.7.0
+    version: "$config_version"
+
+  min_version: 2023.12.0
 
 esp32:
   board: esp32-c3-devkitm-1
+
+# esp32_improv:  # Uses around 30% of available flash space due to loading BLE stack
+#   authorizer: none
 
 # Enable logging
 # https://esphome.io/components/logger.html
@@ -41,3 +46,9 @@ i2c:
   sda: GPIO7 # Pin 21
   scl: GPIO6 # Pin 20
   frequency: 400kHz  # 400kHz eliminates warnings about components taking a long time other than SGP40 component: https://github.com/esphome/issues/issues/4717
+
+button:
+  - platform: factory_reset
+    disabled_by_default: true
+    name: "Factory Reset ESP"
+    id: factory_reset_all

--- a/packages/diagnostic.yaml
+++ b/packages/diagnostic.yaml
@@ -1,0 +1,13 @@
+sensor:
+  - platform: internal_temperature
+    name: "ESP Temperature"
+    id: sys_esp_temperature
+
+  - platform: template
+    id: esp_memory
+    icon: mdi:memory
+    name: ESP Free Memory
+    lambda: return heap_caps_get_free_size(MALLOC_CAP_INTERNAL) / 1024;
+    unit_of_measurement: "kB"
+    state_class: measurement
+    entity_category: "diagnostic"

--- a/packages/display_sh1106_multi_page.yaml
+++ b/packages/display_sh1106_multi_page.yaml
@@ -66,8 +66,8 @@ display:
         lambda: |-
           it.printf(0, 0, id(open_sans_14), "ID:");
           it.printf(128, 0, id(open_sans_14), TextAlign::TOP_RIGHT, "%s", get_mac_address().c_str());
-          it.printf(0, 21, id(open_sans_14), "Config Ver: $ag_esphome_config_version");
-          it.printf(0, 42, id(open_sans_14), "$friendly_devicename");
+          it.printf(0, 21, id(open_sans_14), "Config Ver: $config_version");
+          it.printf(0, 42, id(open_sans_14), "$friendly_name");
       - id: summary1
         lambda: |-
           it.printf(0, 0, id(poppins_light), "CO2:");
@@ -304,3 +304,21 @@ switch:
     optimistic: True
     entity_category: config
     icon: "mdi:monitor"
+
+number:
+  - platform: template
+    # https://esphome.io/components/number/template.html
+    name: "Display Contrast %"
+    icon: "mdi:lightbulb"
+    id: display_contrast
+    min_value: 0
+    max_value: 100
+    step: 1
+    initial_value: 100
+    optimistic: true
+    restore_value: true
+    mode: slider
+    on_value:
+      then:
+        # https://www.reddit.com/r/Esphome/comments/sy1d1s/how_to_write_a_lamba_to_change_the_contrast_of/
+        lambda: id(oled_display).set_contrast(id(display_contrast).state / 100.0);

--- a/packages/display_sh1106_single_page.yaml
+++ b/packages/display_sh1106_single_page.yaml
@@ -48,8 +48,8 @@ display:
         lambda: |-
           it.printf(0, 0, id(open_sans_14), "ID:");
           it.printf(128, 0, id(open_sans_14), TextAlign::TOP_RIGHT, "%s", get_mac_address().c_str());
-          it.printf(0, 21, id(open_sans_14), "Config Ver: $ag_esphome_config_version");
-          it.printf(0, 42, id(open_sans_14), "$friendly_devicename");
+          it.printf(0, 21, id(open_sans_14), "Config Ver: $config_version");
+          it.printf(0, 42, id(open_sans_14), "$friendly_name");
 
     on_page_change:
       to: boot
@@ -86,3 +86,21 @@ switch:
     id: display_in_f
     restore_mode: RESTORE_DEFAULT_ON
     optimistic: True
+
+number:
+  - platform: template
+    # https://esphome.io/components/number/template.html
+    name: "Display Contrast %"
+    icon: "mdi:lightbulb"
+    id: display_contrast
+    min_value: 0
+    max_value: 100
+    step: 1
+    initial_value: 100
+    optimistic: true
+    restore_value: true
+    mode: slider
+    on_value:
+      then:
+        # https://www.reddit.com/r/Esphome/comments/sy1d1s/how_to_write_a_lamba_to_change_the_contrast_of/
+        lambda: id(oled_display).set_contrast(id(display_contrast).state / 100.0);

--- a/packages/sensor_bme680.yaml
+++ b/packages/sensor_bme680.yaml
@@ -7,32 +7,32 @@ sensor:
   # https://esphome.io/components/sensor/bme680_bsec.html
   - platform: bme680_bsec
     temperature:
-      name: "${friendly_devicename} BME680 BSEC Temperature"
+      name: "BME680 BSEC Temperature"
       id: bme_temp
     pressure:
-      name: "${friendly_devicename} BME680 BSEC Pressure"
+      name: "BME680 BSEC Pressure"
       id: bme_pressure
     humidity:
-      name: "${friendly_devicename} BME680 BSEC Humidity"
+      name: "BME680 BSEC Humidity"
       id: bme_humidity
     iaq:
-      name: "${friendly_devicename} BME680 BSEC IAQ"
+      name: "BME680 BSEC IAQ"
       id: bme_iaq
     co2_equivalent:
-      name: "${friendly_devicename} BME680 BSEC CO2 Equivalent"
+      name: "BME680 BSEC CO2 Equivalent"
       id: bme_eco2
     breath_voc_equivalent:
-      name: "${friendly_devicename} BME680 BSEC Breath VOC Equivalent"
+      name: "BME680 BSEC Breath VOC Equivalent"
       id: bme_voc
 
 text_sensor:
   - platform: bme680_bsec
     iaq_accuracy:
-      name: "${friendly_devicename} BME680 IAQ Accuracy"
+      name: "BME680 IAQ Accuracy"
       id: iaq_accuracy
 
   - platform: template
-    name: "${friendly_devicename} BME680 IAQ Classification"
+    name: "BME680 IAQ Classification"
     icon: "mdi:checkbox-marked-circle-outline"
     id: iaq_classification
     lambda: |-

--- a/packages/sensor_pms5003.yaml
+++ b/packages/sensor_pms5003.yaml
@@ -7,6 +7,7 @@ sensor:
     pm_2_5:
       name: "PM 2.5"
       id: pm_2_5
+      device_class: pm25  # Added to report properly to Homekit
       filters:
         - sliding_window_moving_average:
             window_size: 30
@@ -14,6 +15,7 @@ sensor:
     pm_1_0:
       name: "PM 1.0"
       id: pm_1_0
+      device_class: pm1  # Added to report properly to Homekit
       filters:
         - sliding_window_moving_average:
             window_size: 30
@@ -21,6 +23,7 @@ sensor:
     pm_10_0:
       name: "PM 10.0"
       id: pm_10_0
+      device_class: pm10  # Added to report properly to Homekit
       filters:
         - sliding_window_moving_average:
             window_size: 30

--- a/packages/sensor_pms5003.yaml
+++ b/packages/sensor_pms5003.yaml
@@ -7,7 +7,7 @@ sensor:
     pm_2_5:
       name: "PM 2.5"
       id: pm_2_5
-      device_class: pm25  # Added to report properly to Homekit
+      device_class: pm25  # Added to report properly to HomeKit
       filters:
         - sliding_window_moving_average:
             window_size: 30
@@ -15,7 +15,7 @@ sensor:
     pm_1_0:
       name: "PM 1.0"
       id: pm_1_0
-      device_class: pm1  # Added to report properly to Homekit
+      device_class: pm1  # Added to report properly to HomeKit
       filters:
         - sliding_window_moving_average:
             window_size: 30
@@ -23,7 +23,7 @@ sensor:
     pm_10_0:
       name: "PM 10.0"
       id: pm_10_0
-      device_class: pm10  # Added to report properly to Homekit
+      device_class: pm10  # Added to report properly to HomeKit
       filters:
         - sliding_window_moving_average:
             window_size: 30

--- a/packages/sensor_pms5003_extended_life.yaml
+++ b/packages/sensor_pms5003_extended_life.yaml
@@ -7,12 +7,15 @@ sensor:
     pm_2_5:
       name: "PM 2.5"
       id: pm_2_5
+      device_class: pm25  # Added to report properly to Homekit
     pm_1_0:
       name: "PM 1.0"
       id: pm_1_0
+      device_class: pm1  # Added to report properly to Homekit
     pm_10_0:
       name: "PM 10.0"
       id: pm_10_0
+      device_class: pm10  # Added to report properly to Homekit
     pm_0_3um:
       name: "PM 0.3"
       id: pm_0_3um

--- a/packages/sensor_pms5003_extended_life.yaml
+++ b/packages/sensor_pms5003_extended_life.yaml
@@ -7,15 +7,15 @@ sensor:
     pm_2_5:
       name: "PM 2.5"
       id: pm_2_5
-      device_class: pm25  # Added to report properly to Homekit
+      device_class: pm25  # Added to report properly to HomeKit
     pm_1_0:
       name: "PM 1.0"
       id: pm_1_0
-      device_class: pm1  # Added to report properly to Homekit
+      device_class: pm1  # Added to report properly to HomeKit
     pm_10_0:
       name: "PM 10.0"
       id: pm_10_0
-      device_class: pm10  # Added to report properly to Homekit
+      device_class: pm10  # Added to report properly to HomeKit
     pm_0_3um:
       name: "PM 0.3"
       id: pm_0_3um

--- a/packages/sensor_pms5003t.yaml
+++ b/packages/sensor_pms5003t.yaml
@@ -7,6 +7,7 @@ sensor:
     pm_2_5:
       name: "PM 2.5"
       id: pm_2_5
+      device_class: pm25  # Added to report properly to Homekit
       filters:
         - sliding_window_moving_average:
             window_size: 30
@@ -14,6 +15,7 @@ sensor:
     pm_1_0:
       name: "PM 1.0"
       id: pm_1_0
+      device_class: pm1  # Added to report properly to Homekit
       filters:
         - sliding_window_moving_average:
             window_size: 30
@@ -21,6 +23,7 @@ sensor:
     pm_10_0:
       name: "PM 10.0"
       id: pm_10_0
+      device_class: pm10  # Added to report properly to Homekit
       filters:
         - sliding_window_moving_average:
             window_size: 30

--- a/packages/sensor_pms5003t.yaml
+++ b/packages/sensor_pms5003t.yaml
@@ -7,7 +7,7 @@ sensor:
     pm_2_5:
       name: "PM 2.5"
       id: pm_2_5
-      device_class: pm25  # Added to report properly to Homekit
+      device_class: pm25  # Added to report properly to HomeKit
       filters:
         - sliding_window_moving_average:
             window_size: 30
@@ -15,7 +15,7 @@ sensor:
     pm_1_0:
       name: "PM 1.0"
       id: pm_1_0
-      device_class: pm1  # Added to report properly to Homekit
+      device_class: pm1  # Added to report properly to HomeKit
       filters:
         - sliding_window_moving_average:
             window_size: 30
@@ -23,7 +23,7 @@ sensor:
     pm_10_0:
       name: "PM 10.0"
       id: pm_10_0
-      device_class: pm10  # Added to report properly to Homekit
+      device_class: pm10  # Added to report properly to HomeKit
       filters:
         - sliding_window_moving_average:
             window_size: 30

--- a/packages/sensor_pms5003t_extended_life.yaml
+++ b/packages/sensor_pms5003t_extended_life.yaml
@@ -7,12 +7,15 @@ sensor:
     pm_2_5:
       name: "PM 2.5"
       id: pm_2_5
+      device_class: pm25  # Added to report properly to Homekit
     pm_1_0:
       name: "PM 1.0"
       id: pm_1_0
+      device_class: pm1  # Added to report properly to Homekit
     pm_10_0:
       name: "PM 10.0"
       id: pm_10_0
+      device_class: pm10  # Added to report properly to Homekit
     pm_0_3um:
       name: "PM 0.3"
       id: pm_0_3um

--- a/packages/sensor_pms5003t_extended_life.yaml
+++ b/packages/sensor_pms5003t_extended_life.yaml
@@ -7,15 +7,15 @@ sensor:
     pm_2_5:
       name: "PM 2.5"
       id: pm_2_5
-      device_class: pm25  # Added to report properly to Homekit
+      device_class: pm25  # Added to report properly to HomeKit
     pm_1_0:
       name: "PM 1.0"
       id: pm_1_0
-      device_class: pm1  # Added to report properly to Homekit
+      device_class: pm1  # Added to report properly to HomeKit
     pm_10_0:
       name: "PM 10.0"
       id: pm_10_0
-      device_class: pm10  # Added to report properly to Homekit
+      device_class: pm10  # Added to report properly to HomeKit
     pm_0_3um:
       name: "PM 0.3"
       id: pm_0_3um


### PR DESCRIPTION
## Breaking Changes

In the 2.x release of these configurations, some breaking changes are introduced

* See previous 1.x release breaking changes if coming from earlier versions
* Changed `name_add_mac_suffix` to false by default.  This will no longer add the MAC address to the end of the device name.  Assists ESPHome in properly detecting new device as Online without a static IP.  Can be changed to `true` if desired. Ensure all devices have unique `name:` fields if `false`.
* Changed the variable names in the `substitutions:` section to have them match the ESPHome parameters they are used with.
* Changed to `config_version:` substitution name for a shorter name
* Disabled Upload to AirGradient Dashboard by default, but able to flip the switch in HomeAssistant to enable if desired

## Changes

* Added Display Contrast slider to dim the display
* Added device_class to the PMSx005 sensors to have them properly reflect in the HomeKit integration if supported ([Forum Link](https://forum.airgradient.com/t/airgradient-one-customized-mallocarray-esphome-display/1328/7?u=mallocarray))
* Added optional Factory Reset switch that is disabled by default. Can be enabled in HomeAssistant and used if desired
* Added optional `diagnostic.yaml` package with extra sensors about the ESP device itself, including temperature and free
* Added optional `sensor_bme680.yaml` package to support the BME680 module if desired
* Added `dashboard_import` to assist discovery of new devices installed with the pre-compiled .bin files