### PR TITLE
Outdoor temp hum compensation

### DIFF
--- a/airgradient-open-air-o-1pst.yaml
+++ b/airgradient-open-air-o-1pst.yaml
@@ -5,7 +5,7 @@
 substitutions:
   name: "ag-open-air-o-1pst"
   friendly_name: "AG Open Air O-1PST"
-  config_version: 2.0.0
+  config_version: 2.0.1
   name_add_mac_suffix: "false"  # Must have quotes around value
 
 # Enable Home Assistant API

--- a/packages/sensor_pms5003t.yaml
+++ b/packages/sensor_pms5003t.yaml
@@ -40,7 +40,13 @@ sensor:
       id: temp
       filters:
           # https://www.airgradient.com/blog/slr-temperature-example/
-        - lambda: return (x - 4.55) / 0.83;
+          # - lambda: return (x - 4.55) / 0.83;  # Once the negative number issue fix is merged in https://github.com/esphome/issues/issues/3814
+        - lambda: !lambda |-
+            // Fix negative values for now
+            if (x > 6000) {
+              return (x - 6553.6 - 4.55) / 0.83;
+            }
+            return (x - 4.55) / 0.83;
         - sliding_window_moving_average:
             window_size: 30
             send_every: 30
@@ -66,7 +72,7 @@ sensor:
     icon: "mdi:air-filter"
     accuracy_decimals: 0
     filters:
-      - skip_initial: 10  # Need valid data from PM 2.5 sensor before able to calculate
+      - skip_initial: 1  # Need valid data from PM 2.5 sensor before able to calculate
     lambda: |-
       // https://en.wikipedia.org/wiki/Air_quality_index#Computing_the_AQI
       // Borrowed from https://github.com/kylemanna/sniffer/blob/master/esphome/sniffer_common.yaml

--- a/packages/sensor_pms5003t_extended_life.yaml
+++ b/packages/sensor_pms5003t_extended_life.yaml
@@ -24,7 +24,13 @@ sensor:
       id: temp
       filters:
           # https://www.airgradient.com/blog/slr-temperature-example/
-        - lambda: return (x - 4.55) / 0.83;
+          # - lambda: return (x - 4.55) / 0.83;  # Once the negative number issue fix is merged in https://github.com/esphome/issues/issues/3814
+        - lambda: !lambda |-
+            // Fix negative values for now
+            if (x > 6000) {
+              return (x - 6553.6 - 4.55) / 0.83;
+            }
+            return (x - 4.55) / 0.83;
     humidity:
       name: "Humidity"
       id: humidity

--- a/packages/sensor_pms5003t_extended_life.yaml
+++ b/packages/sensor_pms5003t_extended_life.yaml
@@ -7,24 +7,32 @@ sensor:
     pm_2_5:
       name: "PM 2.5"
       id: pm_2_5
-      device_class: pm25  # Added to report properly to HomeKit
+      device_class: pm25  # Added to report properly to Homekit
     pm_1_0:
       name: "PM 1.0"
       id: pm_1_0
-      device_class: pm1  # Added to report properly to HomeKit
+      device_class: pm1  # Added to report properly to Homekit
     pm_10_0:
       name: "PM 10.0"
       id: pm_10_0
-      device_class: pm10  # Added to report properly to HomeKit
+      device_class: pm10  # Added to report properly to Homekit
     pm_0_3um:
       name: "PM 0.3"
       id: pm_0_3um
     temperature:
       name: "Temperature"
       id: temp
+      filters:
+          # https://www.airgradient.com/blog/slr-temperature-example/
+        - lambda: return (x - 4.55) / 0.83;
     humidity:
       name: "Humidity"
       id: humidity
+      filters:
+          # https://www.airgradient.com/blog/linear-regression-improves-sensor-accuracy/
+        # - lambda: return x * 1.500574 - 4.76;
+          # https://forum.airgradient.com/t/open-air-outdoor-air-quality-monitor-humidity-readings-are-off/1171/2
+        - lambda: return x * 1.3921 - 1.0245;
     update_interval: 2min
 
 
@@ -37,7 +45,7 @@ sensor:
     icon: "mdi:air-filter"
     accuracy_decimals: 0
     filters:
-      - skip_initial: 10  # Need valid data from PM 2.5 sensor before able to calculate
+      - skip_initial: 1  # Need valid data from PM 2.5 sensor before able to calculate
     lambda: |-
       // https://en.wikipedia.org/wiki/Air_quality_index#Computing_the_AQI
       // Borrowed from https://github.com/kylemanna/sniffer/blob/master/esphome/sniffer_common.yaml

--- a/packages/sensor_pms5003t_uncorrected.yaml
+++ b/packages/sensor_pms5003t_uncorrected.yaml
@@ -39,8 +39,6 @@ sensor:
       name: "Temperature"
       id: temp
       filters:
-          # https://www.airgradient.com/blog/slr-temperature-example/
-        - lambda: return (x - 4.55) / 0.83;
         - sliding_window_moving_average:
             window_size: 30
             send_every: 30
@@ -48,10 +46,6 @@ sensor:
       name: "Humidity"
       id: humidity
       filters:
-          # https://www.airgradient.com/blog/linear-regression-improves-sensor-accuracy/
-        # - lambda: return x * 1.500574 - 4.76;
-          # https://forum.airgradient.com/t/open-air-outdoor-air-quality-monitor-humidity-readings-are-off/1171/2
-        - lambda: return x * 1.3921 - 1.0245;
         - sliding_window_moving_average:
             window_size: 30
             send_every: 30
@@ -66,7 +60,7 @@ sensor:
     icon: "mdi:air-filter"
     accuracy_decimals: 0
     filters:
-      - skip_initial: 10  # Need valid data from PM 2.5 sensor before able to calculate
+      - skip_initial: 1  # Need valid data from PM 2.5 sensor before able to calculate
     lambda: |-
       // https://en.wikipedia.org/wiki/Air_quality_index#Computing_the_AQI
       // Borrowed from https://github.com/kylemanna/sniffer/blob/master/esphome/sniffer_common.yaml


### PR DESCRIPTION
Adds AirGradient research fix for too high temp and too low humidity readings in the PMS5003T sensor inside of the Outdoor enclosures.

Also has a fix for this sensor not handling below 0 C temperatures correctly. Fix in ESPHome is in process, but this has a workaround until then.