### PR TITLE
Update sensor_s8.yaml: reduce co2 minimum to avoid clipping

### DIFF
--- a/packages/sensor_s8.yaml
+++ b/packages/sensor_s8.yaml
@@ -8,7 +8,7 @@ sensor:
       filters:
         - skip_initial: 2
         - clamp:
-            min_value: 400  # 419 as of 2023-06 https://gml.noaa.gov/ccgg/trends/global.html
+            min_value: 350  # 419 global mean as of 2023-06 https://gml.noaa.gov/ccgg/trends/global.html
     id: senseair_s8
     uart_id: senseair_s8_uart
 


### PR DESCRIPTION
In Wellington NZ I'm frequently seeing the floor of 400 being reached on an outdoor O-1PST. Don't know if it's just miscalibrating or what, but I imagine it's normal for there to be some variance around the global mean ppm.

> 23:05:23	[D]	[senseair:059]	
SenseAir Received CO₂=398ppm Status=0x00
> 23:05:23	[D]	[sensor:094]	
'CO2': Sending state 400.00000 ppm with 0 decimals of accuracy