### PR TITLE
Add temperature correction to second pms5003t sensor

### DIFF
--- a/packages/sensor_pms5003t_2.yaml
+++ b/packages/sensor_pms5003t_2.yaml
@@ -40,14 +40,12 @@ sensor:
       name: "Temperature (2)"
       id: temp_2
       filters:
-          # https://www.airgradient.com/blog/slr-temperature-example/
-          # - lambda: return (x - 4.55) / 0.83;  # Once the negative number issue fix is merged in https://github.com/esphome/issues/issues/3814
+          # https://forum.airgradient.com/t/outdoor-temperature-and-humidity-reading-correction/1544/19
         - lambda: !lambda |-
-            // Fix negative values for now
-            if (x > 6000) {
-              return (x - 6553.6 - 4.55) / 0.83;
-            }
-            return (x - 4.55) / 0.83;
+            // Remove line with (x > 6000) once the negative number issue fix is merged in https://github.com/esphome/issues/issues/3814
+            if (x > 6000) return ((x - 6553.6) * 1.327) - 6.738;
+            if (x < 10.0) return (x * 1.327) - 6.738;
+            return (x * 1.181) - 5.113;
         - sliding_window_moving_average:
             window_size: 30
             send_every: 30


### PR DESCRIPTION
Adds temperature correction for "Temperature (2)" and "Temperature (Average)" sensors. Same as https://github.com/MallocArray/airgradient_esphome/commit/435101d6593ecfa4371463ae2f49570cde8cd931#diff-ab684f4d1b65da2d08cc12c2cc8b23ba53e527d37f1acec23de16aa842b4243e