### PR TITLE
Remove workaround for negative number

### DIFF
--- a/full_config/ag-open-air-o-1ppt.yaml
+++ b/full_config/ag-open-air-o-1ppt.yaml
@@ -190,8 +190,6 @@ sensor:
     id: temp
     filters:
     - lambda: !lambda |-
-        // Remove line with (x > 6000) once the negative number issue fix is merged in https://github.com/esphome/issues/issues/3814
-        if (x > 6000) return ((x - 6553.6) * 1.327) - 6.738;
         if (x < 10.0) return (x * 1.327) - 6.738;
         return (x * 1.181) - 5.113;
     - sliding_window_moving_average:
@@ -326,8 +324,6 @@ sensor:
     id: temp_2
     filters:
     - lambda: !lambda |-
-        // Remove line with (x > 6000) once the negative number issue fix is merged in https://github.com/esphome/issues/issues/3814
-        if (x > 6000) return ((x - 6553.6) * 1.327) - 6.738;
         if (x < 10.0) return (x * 1.327) - 6.738;
         return (x * 1.181) - 5.113;
     - sliding_window_moving_average:

--- a/full_config/ag-open-air-o-1pst.yaml
+++ b/full_config/ag-open-air-o-1pst.yaml
@@ -209,8 +209,6 @@ sensor:
     id: temp
     filters:
     - lambda: !lambda |-
-        // Remove line with (x > 6000) once the negative number issue fix is merged in https://github.com/esphome/issues/issues/3814
-        if (x > 6000) return ((x - 6553.6) * 1.327) - 6.738;
         if (x < 10.0) return (x * 1.327) - 6.738;
         return (x * 1.181) - 5.113;
     - sliding_window_moving_average:

--- a/packages/sensor_pms5003t.yaml
+++ b/packages/sensor_pms5003t.yaml
@@ -42,8 +42,6 @@ sensor:
       filters:
           # https://forum.airgradient.com/t/outdoor-temperature-and-humidity-reading-correction/1544/19
         - lambda: !lambda |-
-            // Remove line with (x > 6000) once the negative number issue fix is merged in https://github.com/esphome/issues/issues/3814
-            if (x > 6000) return ((x - 6553.6) * 1.327) - 6.738;
             if (x < 10.0) return (x * 1.327) - 6.738;
             return (x * 1.181) - 5.113;
         - sliding_window_moving_average:

--- a/packages/sensor_pms5003t_2.yaml
+++ b/packages/sensor_pms5003t_2.yaml
@@ -43,8 +43,6 @@ sensor:
       filters:
           # https://forum.airgradient.com/t/outdoor-temperature-and-humidity-reading-correction/1544/19
         - lambda: !lambda |-
-            // Remove line with (x > 6000) once the negative number issue fix is merged in https://github.com/esphome/issues/issues/3814
-            if (x > 6000) return ((x - 6553.6) * 1.327) - 6.738;
             if (x < 10.0) return (x * 1.327) - 6.738;
             return (x * 1.181) - 5.113;
         - sliding_window_moving_average:

--- a/packages/sensor_pms5003t_2_extended_life.yaml
+++ b/packages/sensor_pms5003t_2_extended_life.yaml
@@ -29,8 +29,6 @@ sensor:
       filters:
           # https://forum.airgradient.com/t/outdoor-temperature-and-humidity-reading-correction/1544/19
         - lambda: !lambda |-
-            // Remove line with (x > 6000) once the negative number issue fix is merged in https://github.com/esphome/issues/issues/3814
-            if (x > 6000) return ((x - 6553.6) * 1.327) - 6.738;
             if (x < 10.0) return (x * 1.327) - 6.738;
             return (x * 1.181) - 5.113;
     humidity:

--- a/packages/sensor_pms5003t_extended_life.yaml
+++ b/packages/sensor_pms5003t_extended_life.yaml
@@ -29,8 +29,6 @@ sensor:
       filters:
           # https://forum.airgradient.com/t/outdoor-temperature-and-humidity-reading-correction/1544/19
         - lambda: !lambda |-
-            // Remove line with (x > 6000) once the negative number issue fix is merged in https://github.com/esphome/issues/issues/3814
-            if (x > 6000) return ((x - 6553.6) * 1.327) - 6.738;
             if (x < 10.0) return (x * 1.327) - 6.738;
             return (x * 1.181) - 5.113;
     humidity:


### PR DESCRIPTION
The issue with negative values for PMS5003T has been fixed (see https://github.com/esphome/issues/issues/3814), so this workaround is no longer needed.