### PR TITLE
Switch API calls to use https

### DIFF
--- a/packages/airgradient_api_d1_mini.yaml
+++ b/packages/airgradient_api_d1_mini.yaml
@@ -10,7 +10,7 @@ interval:
               # https://api.airgradient.com/public/docs/api/v1/
               # AirGradient URL with the last 6 of MAC address all lower case
               url: !lambda |-
-                return "http://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
+                return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
               headers:
                   Content-Type: application/json
               json:
@@ -48,7 +48,7 @@ esphome:
             # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
             # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
             url: !lambda |-
-              return "http://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
+              return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
             headers:
                 Content-Type: application/json
             json:

--- a/packages/airgradient_api_d1_mini_no_sgp41.yaml
+++ b/packages/airgradient_api_d1_mini_no_sgp41.yaml
@@ -10,7 +10,7 @@ interval:
               # https://api.airgradient.com/public/docs/api/v1/
               # AirGradient URL with the last 6 of MAC address all lower case
               url: !lambda |-
-                return "http://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
+                return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
               headers:
                   Content-Type: application/json
               json:
@@ -46,7 +46,7 @@ esphome:
             # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
             # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
             url: !lambda |-
-              return "http://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
+              return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
             headers:
                 Content-Type: application/json
             json:

--- a/packages/airgradient_api_esp32-c3.yaml
+++ b/packages/airgradient_api_esp32-c3.yaml
@@ -10,7 +10,7 @@ interval:
               # https://api.airgradient.com/public/docs/api/v1/
               # AirGradient URL with the MAC address all lower case
               url: !lambda |-
-                return "http://hw.airgradient.com/sensors/airgradient:" + get_mac_address() + "/measures";
+                return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address() + "/measures";
               headers:
                   Content-Type: application/json
               json:
@@ -50,7 +50,7 @@ esphome:
             # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
             # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
             url: !lambda |-
-              return "http://hw.airgradient.com/sensors/airgradient:" + get_mac_address() + "/measures";
+              return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address() + "/measures";
             headers:
                 Content-Type: application/json
             json:

--- a/packages/airgradient_api_esp32-c3_dual_pms5003t.yaml
+++ b/packages/airgradient_api_esp32-c3_dual_pms5003t.yaml
@@ -11,7 +11,7 @@ interval:
               # https://api.airgradient.com/public/docs/api/v1/
               # AirGradient URL with the MAC address all lower case
               url: !lambda |-
-                return "http://hw.airgradient.com/sensors/airgradient:" + get_mac_address() + "/measures";
+                return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address() + "/measures";
               headers:
                   Content-Type: application/json
               # "!lambda return to_string(id(pm_2_5).state);" Converts sensor output from double to string
@@ -82,7 +82,7 @@ esphome:
             # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
             # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
             url: !lambda |-
-              return "http://hw.airgradient.com/sensors/airgradient:" + get_mac_address() + "/measures";
+              return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address() + "/measures";
             headers:
                 Content-Type: application/json
             json:

--- a/packages/airgradient_d1_mini_board.yaml
+++ b/packages/airgradient_d1_mini_board.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  config_version: 4.0.1
+  config_version: 4.0.2
 
 esphome:
   name: "${name}"

--- a/packages/airgradient_esp32-c3_board.yaml
+++ b/packages/airgradient_esp32-c3_board.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  config_version: 4.0.1
+  config_version: 4.0.2
 
 esphome:
   name: "${name}"


### PR DESCRIPTION
Stock firmware only used http originally.

There is now a request in the stock firmware to switch to https.  Since that is supported, switched to use the more secure method.