### PR TITLE
Removing "AQI" unit for PM 2.5 AQI sensor

### DIFF
--- a/packages/sensor_pms5003t.yaml
+++ b/packages/sensor_pms5003t.yaml
@@ -92,7 +92,6 @@ sensor:
     id: pm_2_5_aqi
     update_interval: 5 min
     device_class: aqi
-    unit_of_measurement: "AQI"
     icon: "mdi:air-filter"
     accuracy_decimals: 0
     filters:


### PR DESCRIPTION
Home Assistant does not expect any unit of measurement and throws a warning here:

>Entity sensor.ag_open_air_o_1pst_pm_2_5_aqi (<class 'homeassistant.components.esphome.sensor.EsphomeSensor'>) is using native unit of measurement 'AQI' which is not a valid unit for the device class ('aqi') it is using; expected one of ['no unit of measurement'];