### PR TITLE
pms5003t: debounce sensor updates

### DIFF
--- a/packages/sensor_pms5003t.yaml
+++ b/packages/sensor_pms5003t.yaml
@@ -9,27 +9,39 @@ sensor:
       id: pm_2_5_raw
       device_class: pm25  # Added to report properly to HomeKit
       disabled_by_default: true
+      filters:
+        - debounce: 0.33s
     pm_1_0:
       name: "PM 1.0"
       id: pm_1_0
       device_class: pm1  # Added to report properly to HomeKit
+      filters:
+        - debounce: 0.33s
     pm_10_0:
       name: "PM 10.0"
       id: pm_10_0
       device_class: pm10  # Added to report properly to HomeKit
+      filters:
+        - debounce: 0.33s
     pm_0_3um:
       name: "PM 0.3"
       id: pm_0_3um
+      filters:
+        - debounce: 0.33s
     temperature:
       name: "Temperature Raw"
       id: temp_raw
       icon: "mdi:thermometer"
       disabled_by_default: true
+      filters:
+        - debounce: 0.33s
     humidity:
       name: "Humidity Raw"
       id: humidity_raw
       icon: "mdi:water-percent"
       disabled_by_default: true
+      filters:
+        - debounce: 0.33s
     update_interval: 30s
 
   - platform: copy

--- a/packages/sensor_pms5003t_2.yaml
+++ b/packages/sensor_pms5003t_2.yaml
@@ -10,27 +10,39 @@ sensor:
       id: pm_2_5_2_raw
       device_class: pm25  # Added to report properly to HomeKit
       disabled_by_default: true
+      filters:
+        - debounce: 0.33s
     pm_1_0:
       name: "PM 1.0 (2)"
       id: pm_1_0_2
       device_class: pm1  # Added to report properly to HomeKit
+      filters:
+        - debounce: 0.33s
     pm_10_0:
       name: "PM 10.0 (2)"
       id: pm_10_0_2
       device_class: pm10  # Added to report properly to HomeKit
+      filters:
+        - debounce: 0.33s
     pm_0_3um:
       name: "PM 0.3 (2)"
       id: pm_0_3um_2
+      filters:
+        - debounce: 0.33s
     temperature:
       name: "Temperature (2) Raw"
       id: temp_2_raw
       icon: "mdi:thermometer"
       disabled_by_default: true
+      filters:
+        - debounce: 0.33s
     humidity:
       name: "Humidity (2) Raw"
       id: humidity_2_raw
       icon: "mdi:water-percent"
       disabled_by_default: true
+      filters:
+        - debounce: 0.33s
     update_interval: 30s
 
   - platform: copy

--- a/packages/sensor_pms5003t_2_extended_life.yaml
+++ b/packages/sensor_pms5003t_2_extended_life.yaml
@@ -12,27 +12,39 @@ sensor:
       id: pm_2_5_2_raw
       device_class: pm25  # Added to report properly to HomeKit
       disabled_by_default: true
+      filters:
+        - debounce: 0.33s
     pm_1_0:
       name: "PM 1.0 (2)"
       id: pm_1_0_2
       device_class: pm1  # Added to report properly to HomeKit
+      filters:
+        - debounce: 0.33s
     pm_10_0:
       name: "PM 10.0 (2)"
       id: pm_10_0_2
       device_class: pm10  # Added to report properly to HomeKit
+      filters:
+        - debounce: 0.33s
     pm_0_3um:
       name: "PM 0.3 (2)"
       id: pm_0_3um_2
+      filters:
+        - debounce: 0.33s
     temperature:
       name: "Temperature (2) Raw"
       id: temp_2_raw
       icon: "mdi:thermometer"
       disabled_by_default: true
+      filters:
+        - debounce: 0.33s
     humidity:
       name: "Humidity (2) Raw"
       id: humidity_2_raw
       icon: "mdi:water-percent"
       disabled_by_default: true
+      filters:
+        - debounce: 0.33s
     update_interval: $pm_update_interval
 
 

--- a/packages/sensor_pms5003t_extended_life.yaml
+++ b/packages/sensor_pms5003t_extended_life.yaml
@@ -12,27 +12,39 @@ sensor:
       id: pm_2_5_raw
       device_class: pm25  # Added to report properly to HomeKit
       disabled_by_default: true
+      filters:
+        - debounce: 0.33s
     pm_1_0:
       name: "PM 1.0"
       id: pm_1_0
       device_class: pm1  # Added to report properly to HomeKit
+      filters:
+        - debounce: 0.33s
     pm_10_0:
       name: "PM 10.0"
       id: pm_10_0
       device_class: pm10  # Added to report properly to HomeKit
+      filters:
+        - debounce: 0.33s
     pm_0_3um:
       name: "PM 0.3"
       id: pm_0_3um
+      filters:
+        - debounce: 0.33s
     temperature:
       name: "Temperature Raw"
       id: temp_raw
       icon: "mdi:thermometer"
       disabled_by_default: true
+      filters:
+        - debounce: 0.33s
     humidity:
       name: "Humidity Raw"
       id: humidity_raw
       icon: "mdi:water-percent"
       disabled_by_default: true
+      filters:
+        - debounce: 0.33s
     update_interval: $pm_update_interval
 
   - platform: copy


### PR DESCRIPTION
Looking at debug logs and/or MQTT I'm seeing that my PMS5003T will always produce a rapid burst of updates every `update_period` interval.

```
[20:56:58][D][pmsx003:285]: Got PM1.0 Concentration: 20 µg/m^3, PM2.5 Concentration 35 µg/m^3, PM10.0 Concentration: 39 µg/m^3, Temperature: 22.3°C, Humidity: 66.4%
[20:56:58][D][pmsx003:285]: Got PM1.0 Concentration: 20 µg/m^3, PM2.5 Concentration 35 µg/m^3, PM10.0 Concentration: 39 µg/m^3, Temperature: 22.3°C, Humidity: 66.4%
[20:56:58][D][pmsx003:285]: Got PM1.0 Concentration: 20 µg/m^3, PM2.5 Concentration 35 µg/m^3, PM10.0 Concentration: 39 µg/m^3, Temperature: 22.3°C, Humidity: 66.4%
[20:56:58][D][pmsx003:285]: Got PM1.0 Concentration: 21 µg/m^3, PM2.5 Concentration 35 µg/m^3, PM10.0 Concentration: 40 µg/m^3, Temperature: 22.3°C, Humidity: 66.4%
[20:56:58][D][pmsx003:285]: Got PM1.0 Concentration: 21 µg/m^3, PM2.5 Concentration 35 µg/m^3, PM10.0 Concentration: 40 µg/m^3, Temperature: 22.3°C, Humidity: 66.5%
[20:56:58][D][pmsx003:285]: Got PM1.0 Concentration: 21 µg/m^3, PM2.5 Concentration 35 µg/m^3, PM10.0 Concentration: 40 µg/m^3, Temperature: 22.3°C, Humidity: 66.5%
[20:56:58][D][pmsx003:285]: Got PM1.0 Concentration: 21 µg/m^3, PM2.5 Concentration 35 µg/m^3, PM10.0 Concentration: 39 µg/m^3, Temperature: 22.3°C, Humidity: 66.5%
[20:56:58][D][pmsx003:285]: Got PM1.0 Concentration: 21 µg/m^3, PM2.5 Concentration 35 µg/m^3, PM10.0 Concentration: 39 µg/m^3, Temperature: 22.3°C, Humidity: 66.5%
[20:56:58][D][pmsx003:285]: Got PM1.0 Concentration: 21 µg/m^3, PM2.5 Concentration 35 µg/m^3, PM10.0 Concentration: 39 µg/m^3, Temperature: 22.3°C, Humidity: 66.6%
[20:56:58][D][pmsx003:285]: Got PM1.0 Concentration: 20 µg/m^3, PM2.5 Concentration 32 µg/m^3, PM10.0 Concentration: 34 µg/m^3, Temperature: 22.3°C, Humidity: 66.6%
...
[20:57:28][D][pmsx003:285]: Got PM1.0 Concentration: 20 µg/m^3, PM2.5 Concentration 32 µg/m^3, PM10.0 Concentration: 34 µg/m^3, Temperature: 22.3°C, Humidity: 66.6%
[20:57:28][D][pmsx003:285]: Got PM1.0 Concentration: 20 µg/m^3, PM2.5 Concentration 31 µg/m^3, PM10.0 Concentration: 34 µg/m^3, Temperature: 22.3°C, Humidity: 66.6%
[20:57:28][D][pmsx003:285]: Got PM1.0 Concentration: 20 µg/m^3, PM2.5 Concentration 31 µg/m^3, PM10.0 Concentration: 33 µg/m^3, Temperature: 22.2°C, Humidity: 66.6%
[20:57:28][D][pmsx003:285]: Got PM1.0 Concentration: 20 µg/m^3, PM2.5 Concentration 31 µg/m^3, PM10.0 Concentration: 33 µg/m^3, Temperature: 22.3°C, Humidity: 66.6%
[20:57:28][D][pmsx003:285]: Got PM1.0 Concentration: 20 µg/m^3, PM2.5 Concentration 32 µg/m^3, PM10.0 Concentration: 34 µg/m^3, Temperature: 22.3°C, Humidity: 66.6%
[20:57:28][D][pmsx003:285]: Got PM1.0 Concentration: 20 µg/m^3, PM2.5 Concentration 32 µg/m^3, PM10.0 Concentration: 34 µg/m^3, Temperature: 22.3°C, Humidity: 66.6%
[20:57:28][D][pmsx003:285]: Got PM1.0 Concentration: 20 µg/m^3, PM2.5 Concentration 31 µg/m^3, PM10.0 Concentration: 33 µg/m^3, Temperature: 22.3°C, Humidity: 66.6%
[20:57:28][D][pmsx003:285]: Got PM1.0 Concentration: 21 µg/m^3, PM2.5 Concentration 31 µg/m^3, PM10.0 Concentration: 33 µg/m^3, Temperature: 22.2°C, Humidity: 66.6%
[20:57:28][D][pmsx003:285]: Got PM1.0 Concentration: 20 µg/m^3, PM2.5 Concentration 32 µg/m^3, PM10.0 Concentration: 33 µg/m^3, Temperature: 22.3°C, Humidity: 66.6%
```

I'm not sure exactly what is the root cause between these repeat readings: is it buffering updates for 30 seconds and then dumps them all at once; or is it actually taking this many samples in the short period ESPHome has the sensor enabled…? You can see that the readings change between these samples, sometimes quite significantly so, which suggests it is actually buffering, but I really don't know.

Either way this results in a significant excessive sensor update traffic as a result. Assuming that the most recent sample is closest to the "current" state, the `debounce` filter is a perfect fit as it will only let through the last sample observed within the 1 second interval.

I didn't touch PMS5003 code, as I'm not sure if it suffers from the same issue.