### PR TITLE
Remove unit_of_measurement: "AQI"

### DIFF
--- a/packages/sensor_pms5003.yaml
+++ b/packages/sensor_pms5003.yaml
@@ -54,7 +54,6 @@ sensor:
     id: pm_2_5_aqi
     update_interval: 5 min
     device_class: aqi
-    unit_of_measurement: "AQI"
     icon: "mdi:air-filter"
     accuracy_decimals: 0
     filters:

--- a/packages/sensor_pms5003_extended_life.yaml
+++ b/packages/sensor_pms5003_extended_life.yaml
@@ -50,7 +50,6 @@ sensor:
     name: "PM 2.5 AQI"
     id: pm_2_5_aqi
     update_interval: 5 min
-    unit_of_measurement: "AQI"
     icon: "mdi:air-filter"
     accuracy_decimals: 0
     filters:

--- a/packages/sensor_pms5003_uncorrected.yaml
+++ b/packages/sensor_pms5003_uncorrected.yaml
@@ -30,7 +30,6 @@ sensor:
     id: pm_2_5_aqi
     device_class: aqi
     update_interval: 5 min
-    unit_of_measurement: "AQI"
     icon: "mdi:air-filter"
     accuracy_decimals: 0
     filters:

--- a/packages/sensor_pms5003t_uncorrected.yaml
+++ b/packages/sensor_pms5003t_uncorrected.yaml
@@ -59,7 +59,6 @@ sensor:
     id: pm_2_5_aqi
     update_interval: 5 min
     device_class: aqi
-    unit_of_measurement: "AQI"
     icon: "mdi:air-filter"
     accuracy_decimals: 0
     filters:


### PR DESCRIPTION
Logs show:
Entity sensor.ag_open_air_o_1pst_pm_2_5_aqi (<class 'homeassistant.components.esphome.sensor.EsphomeSensor'>) is using native unit of measurement 'AQI' which is not a valid unit for the device class ('aqi') it is using; expected one of ['no unit of measurement'];

Fixed in some files, but this addresses remaining ones