### PR TITLE
Switch ESP32 to esp-idf framework

### DIFF
--- a/packages/airgradient_d1_mini_board.yaml
+++ b/packages/airgradient_d1_mini_board.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  config_version: 4.0.7
+  config_version: 4.0.8
 
 esphome:
   name: "${name}"
@@ -20,8 +20,6 @@ esp8266:
 logger:
   logs:
     component: ERROR  # Hiding warning messages about component taking a long time https://github.com/esphome/issues/issues/4717
-
-# web_server:  # Please note that enabling this component will take up a lot of memory and may decrease stability, especially on ESP8266.
 
 uart:
   # https://esphome.io/components/uart.html#uart

--- a/packages/airgradient_esp32-c3_board-arduino.yaml
+++ b/packages/airgradient_esp32-c3_board-arduino.yaml
@@ -13,8 +13,6 @@ esphome:
 
 esp32:
   board: esp32-c3-devkitm-1
-  framework:
-    type: esp-idf
 
 # Enable logging
 # https://esphome.io/components/logger.html


### PR DESCRIPTION
Switch from Arduino framework to esp-idf
Reduces memory usage slightly and enables other optional features like bluetooth_proxy and esp32_improv, although they can take up significant amount of memory.

Only available for ESP32 devices, so ESP8266 based devices, such as the AirGradient Basic DIY and Pro remain on Arduino framework