### PR TITLE
Drop overly specific and potentially wrong S8 from entity names

### DIFF
--- a/packages/airgradient_d1_mini_board.yaml
+++ b/packages/airgradient_d1_mini_board.yaml
@@ -26,7 +26,7 @@ uart:
   - rx_pin: D4
     tx_pin: D3
     baud_rate: 9600
-    id: senseair_s8_uart
+    id: senseair_co2_uart
 
   - rx_pin: D5
     tx_pin: D6

--- a/packages/airgradient_esp32-c3_board-arduino.yaml
+++ b/packages/airgradient_esp32-c3_board-arduino.yaml
@@ -25,7 +25,7 @@ uart:
   - rx_pin: GPIO0  # Pin 12
     tx_pin: GPIO1  # Pin 13
     baud_rate: 9600
-    id: senseair_s8_uart
+    id: senseair_co2_uart
 
   - rx_pin: GPIO20  # Pin 30 or RX
     tx_pin: GPIO21  # Pin 31 or TX

--- a/packages/airgradient_esp32-c3_board.yaml
+++ b/packages/airgradient_esp32-c3_board.yaml
@@ -27,7 +27,7 @@ uart:
   - rx_pin: GPIO0  # Pin 12
     tx_pin: GPIO1  # Pin 13
     baud_rate: 9600
-    id: senseair_s8_uart
+    id: senseair_co2_uart
 
   - rx_pin: GPIO20  # Pin 30 or RX
     tx_pin: GPIO21  # Pin 31 or TX

--- a/packages/config_button.yaml
+++ b/packages/config_button.yaml
@@ -21,6 +21,6 @@ binary_sensor:
           - OFF for at least 0.5s
         then:
           - logger.log: "Starting manual CO2 calibration"
-          - senseair.background_calibration: senseair_s8
+          - senseair.background_calibration: senseair_co2
           - delay: 70s
-          - senseair.background_calibration_result: senseair_s8
+          - senseair.background_calibration_result: senseair_co2

--- a/packages/sensor_pms5003t_2.yaml
+++ b/packages/sensor_pms5003t_2.yaml
@@ -4,7 +4,7 @@ sensor:
     # Default interval of updating every second, but changing to 30 seconds to extend life but keep fan spinning
     # PMS5003T with temperature and humidity https://esphome.io/components/sensor/pmsx003.html
     type: PMS5003T
-    uart_id: senseair_s8_uart
+    uart_id: senseair_co2_uart
     pm_2_5:
       name: "PM 2.5 (2) Raw"
       id: pm_2_5_2_raw

--- a/packages/sensor_pms5003t_2_extended_life.yaml
+++ b/packages/sensor_pms5003t_2_extended_life.yaml
@@ -6,7 +6,7 @@ sensor:
   - platform: pmsx003
     # PMS5003T with temperature and humidity https://esphome.io/components/sensor/pmsx003.html
     type: PMS5003T
-    uart_id: senseair_s8_uart
+    uart_id: senseair_co2_uart
     pm_2_5:
       name: "PM 2.5 (2) Raw"
       id: pm_2_5_2_raw

--- a/packages/sensor_s8.yaml
+++ b/packages/sensor_s8.yaml
@@ -13,36 +13,36 @@ sensor:
       filters:
         - skip_initial: 1  # Sometimes returns 0 at first boot instead of valid data
         - offset: $co2_offset
-    id: senseair_s8
-    uart_id: senseair_s8_uart
+    id: senseair_co2
+    uart_id: senseair_co2_uart
 
 button:
   # https://github.com/esphome/issues/issues/2444
   - platform: template
-    name: SenseAir S8 Calibration
-    id: senseair_s8_calibrate_button
+    name: SenseAir CO2 Calibration
+    id: senseair_co2_calibrate_button
     on_press:
       then:
-        - senseair.background_calibration: senseair_s8
+        - senseair.background_calibration: senseair_co2
         - delay: 70s
-        - senseair.background_calibration_result: senseair_s8
+        - senseair.background_calibration_result: senseair_co2
 
   - platform: template
     # Displays the current ABC interval in the ESPhome logs to verify status
-    name: SenseAir S8 Show Calibration Interval
-    id: senseair_s8_show_calibrate_interval
+    name: SenseAir CO2 Write Calibration Interval To Log
+    id: senseair_co2_abc_get_period
     on_press:
       then:
-        - senseair.abc_get_period: senseair_s8
+        - senseair.abc_get_period: senseair_co2
 
 switch:
   - platform: template
-    name: SenseAir S8 Automatic Baseline Correction
-    id: senseair_s8_abc_switch
+    name: SenseAir CO2 Automatic Baseline Correction
+    id: senseair_co2_abc_switch
     restore_mode: RESTORE_DEFAULT_ON
     optimistic: True
     entity_category: config
     turn_on_action:
-      - senseair.abc_enable: senseair_s8
+      - senseair.abc_enable: senseair_co2
     turn_off_action:
-      - senseair.abc_disable: senseair_s8
+      - senseair.abc_disable: senseair_co2


### PR DESCRIPTION
Keep it nice and short for the UI.

Ref: https://www.airgradient.com/blog/changed-co2-sensor-to-s88/