### PR TITLE
Enable log output via USB

### DIFF
--- a/packages/airgradient_esp32-c3_board-arduino.yaml
+++ b/packages/airgradient_esp32-c3_board-arduino.yaml
@@ -17,7 +17,6 @@ esp32:
 # Enable logging
 # https://esphome.io/components/logger.html
 logger:
-  baud_rate: 0  # Must disable serial logging as it conflicts with pms5003 uart pins and ESP32-C3 only has 2 hardware UART
   logs:
     component: ERROR  # Hiding warning messages about component taking a long time https://github.com/esphome/issues/issues/4717
 

--- a/packages/airgradient_esp32-c3_board.yaml
+++ b/packages/airgradient_esp32-c3_board.yaml
@@ -19,7 +19,6 @@ esp32:
 # Enable logging
 # https://esphome.io/components/logger.html
 logger:
-  baud_rate: 0  # Must disable serial logging as it conflicts with pms5003 uart pins and ESP32-C3 only has 2 hardware UART
   logs:
     component: ERROR  # Hiding warning messages about component taking a long time https://github.com/esphome/issues/issues/4717
 


### PR DESCRIPTION
Log output to USB with ESPHome 2025.2.2 default logger config just works.

Ref: https://esphome.io/components/logger.html#default-hardware-interfaces