### PR TITLE
Move all "Controls" except "LED Strip" to "Config" entity_category

### DIFF
--- a/packages/airgradient_api_d1_mini.yaml
+++ b/packages/airgradient_api_d1_mini.yaml
@@ -35,6 +35,7 @@ switch:
     id: upload_airgradient
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: True
+    entity_category: config
 
 esphome:
   on_boot:

--- a/packages/airgradient_api_d1_mini_insecure.yaml
+++ b/packages/airgradient_api_d1_mini_insecure.yaml
@@ -35,6 +35,7 @@ switch:
     id: upload_airgradient
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: True
+    entity_category: config
 
 esphome:
   on_boot:

--- a/packages/airgradient_api_d1_mini_no_sgp41.yaml
+++ b/packages/airgradient_api_d1_mini_no_sgp41.yaml
@@ -33,6 +33,7 @@ switch:
     id: upload_airgradient
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: True
+    entity_category: config
 
 esphome:
   on_boot:

--- a/packages/airgradient_api_esp32-c3.yaml
+++ b/packages/airgradient_api_esp32-c3.yaml
@@ -37,6 +37,7 @@ switch:
     id: upload_airgradient
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: True
+    entity_category: config
 
 esphome:
   on_boot:

--- a/packages/airgradient_api_esp32-c3_dual_pms5003t.yaml
+++ b/packages/airgradient_api_esp32-c3_dual_pms5003t.yaml
@@ -69,6 +69,7 @@ switch:
     id: upload_airgradient
     restore_mode: RESTORE_DEFAULT_ON
     optimistic: True
+    entity_category: config
 
 esphome:
   on_boot:

--- a/packages/display_sh1106_multi_page.yaml
+++ b/packages/display_sh1106_multi_page.yaml
@@ -342,3 +342,4 @@ number:
       then:
         # https://www.reddit.com/r/Esphome/comments/sy1d1s/how_to_write_a_lamba_to_change_the_contrast_of/
         lambda: id(oled_display).set_contrast(id(display_contrast).state / 100.0);
+    entity_category: config

--- a/packages/led.yaml
+++ b/packages/led.yaml
@@ -8,6 +8,9 @@ light:
     name: "LED Strip"
     id: led_strip
     restore_mode: RESTORE_DEFAULT_OFF
+    # Classify this as primary entity so that it shows up on the Home Assistant
+    # pre-populated default dashboard so `entity_category` is intentionally not
+    # set.
 
 number:
   - platform: template
@@ -22,6 +25,7 @@ number:
     optimistic: true
     restore_value: true
     mode: slider
+    entity_category: config
 
   - platform: template
     # https://esphome.io/components/number/template.html
@@ -35,3 +39,4 @@ number:
     optimistic: true
     restore_value: true
     mode: box
+    entity_category: config

--- a/packages/sensor_s8.yaml
+++ b/packages/sensor_s8.yaml
@@ -21,6 +21,7 @@ button:
   - platform: template
     name: SenseAir CO2 Calibration
     id: senseair_co2_calibrate_button
+    entity_category: config
     on_press:
       then:
         - senseair.background_calibration: senseair_co2
@@ -31,6 +32,7 @@ button:
     # Displays the current ABC interval in the ESPhome logs to verify status
     name: SenseAir CO2 Write Calibration Interval To Log
     id: senseair_co2_abc_get_period
+    entity_category: config
     on_press:
       then:
         - senseair.abc_get_period: senseair_co2


### PR DESCRIPTION
Work better together with Home Assistant pre-populated default dashboard. Also comply with:

> Classification of a non-primary entity. Set to EntityCategory.CONFIG
> for an entity that allows changing the configuration of a device, for
> example, a switch entity, making it possible to turn the background
> illumination of a switch on and off.

Ref: https://developers.home-assistant.io/docs/core/entity/#generic-properties
Ref: https://esphome.io/components/button/#base-button-configuration