### PR TITLE
Allow users to add on_boot entries by converting to list

### DIFF
--- a/packages/airgradient_api_d1_mini.yaml
+++ b/packages/airgradient_api_d1_mini.yaml
@@ -38,21 +38,21 @@ switch:
 
 esphome:
   on_boot:
-    priority: 200  # Network connections setup
-    then:
-      if:
-        condition:
-          switch.is_on: upload_airgradient
-        then:
-        - http_request.post:
-            # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
-            # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
-            url: !lambda |-
-              return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
-            headers:
-                Content-Type: application/json
-            json:
-              wifi: !lambda return to_string(-50);
+    - priority: 200  # Network connections setup
+      then:
+        if:
+          condition:
+            switch.is_on: upload_airgradient
+          then:
+          - http_request.post:
+              # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
+              # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
+              url: !lambda |-
+                return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
+              headers:
+                  Content-Type: application/json
+              json:
+                wifi: !lambda return to_string(-50);
 
 http_request:
   timeout: 1s  # Setting short to try to prevent watchdog reboots https://github.com/esphome/issues/issues/2853

--- a/packages/airgradient_api_d1_mini_insecure.yaml
+++ b/packages/airgradient_api_d1_mini_insecure.yaml
@@ -38,21 +38,21 @@ switch:
 
 esphome:
   on_boot:
-    priority: 200  # Network connections setup
-    then:
-      if:
-        condition:
-          switch.is_on: upload_airgradient
-        then:
-        - http_request.post:
-            # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
-            # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
-            url: !lambda |-
-              return "http://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
-            headers:
-                Content-Type: application/json
-            json:
-              wifi: !lambda return to_string(-50);
+    - priority: 200  # Network connections setup
+      then:
+        if:
+          condition:
+            switch.is_on: upload_airgradient
+          then:
+          - http_request.post:
+              # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
+              # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
+              url: !lambda |-
+                return "http://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
+              headers:
+                  Content-Type: application/json
+              json:
+                wifi: !lambda return to_string(-50);
 
 http_request:
   timeout: 1s  # Setting short to try to prevent watchdog reboots http://github.com/esphome/issues/issues/2853

--- a/packages/airgradient_api_d1_mini_no_sgp41.yaml
+++ b/packages/airgradient_api_d1_mini_no_sgp41.yaml
@@ -36,21 +36,21 @@ switch:
 
 esphome:
   on_boot:
-    priority: 200  # Network connections setup
-    then:
-      if:
-        condition:
-          switch.is_on: upload_airgradient
-        then:
-        - http_request.post:
-            # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
-            # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
-            url: !lambda |-
-              return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
-            headers:
-                Content-Type: application/json
-            json:
-              wifi: !lambda return to_string(-50);
+    - priority: 200  # Network connections setup
+      then:
+        if:
+          condition:
+            switch.is_on: upload_airgradient
+          then:
+          - http_request.post:
+              # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
+              # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
+              url: !lambda |-
+                return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address().substr(6,11) + "/measures";
+              headers:
+                  Content-Type: application/json
+              json:
+                wifi: !lambda return to_string(-50);
 
 http_request:
   timeout: 1s  # Setting short to try to prevent watchdog reboots https://github.com/esphome/issues/issues/2853

--- a/packages/airgradient_api_esp32-c3.yaml
+++ b/packages/airgradient_api_esp32-c3.yaml
@@ -40,21 +40,21 @@ switch:
 
 esphome:
   on_boot:
-    priority: 200  # Network connections setup
-    then:
-      if:
-        condition:
-          switch.is_on: upload_airgradient
-        then:
-        - http_request.post:
-            # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
-            # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
-            url: !lambda |-
-              return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address() + "/measures";
-            headers:
-                Content-Type: application/json
-            json:
-              wifi: !lambda return to_string(-50);
+    - priority: 200  # Network connections setup
+      then:
+        if:
+          condition:
+            switch.is_on: upload_airgradient
+          then:
+          - http_request.post:
+              # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
+              # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
+              url: !lambda |-
+                return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address() + "/measures";
+              headers:
+                  Content-Type: application/json
+              json:
+                wifi: !lambda return to_string(-50);
 
 http_request:
   # Used to support POST request to send data to AirGradient

--- a/packages/airgradient_api_esp32-c3_dual_pms5003t.yaml
+++ b/packages/airgradient_api_esp32-c3_dual_pms5003t.yaml
@@ -72,21 +72,21 @@ switch:
 
 esphome:
   on_boot:
-    priority: 200  # Network connections setup
-    then:
-      if:
-        condition:
-          switch.is_on: upload_airgradient
-        then:
-        - http_request.post:
-            # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
-            # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
-            url: !lambda |-
-              return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address() + "/measures";
-            headers:
-                Content-Type: application/json
-            json:
-              wifi: !lambda return to_string(-50);
+    - priority: 200  # Network connections setup
+      then:
+        if:
+          condition:
+            switch.is_on: upload_airgradient
+          then:
+          - http_request.post:
+              # Return wifi signal -50 as soon as device boots to show activity on AirGradient Dashboard site
+              # Using -50 instead of actual value as the wifi_signal sensor has not reported a value at this point in boot process
+              url: !lambda |-
+                return "https://hw.airgradient.com/sensors/airgradient:" + get_mac_address() + "/measures";
+              headers:
+                  Content-Type: application/json
+              json:
+                wifi: !lambda return to_string(-50);
 
 http_request:
   # Used to support POST request to send data to AirGradient


### PR DESCRIPTION
Without this, YAML merging will just overwrite one of the `esphome.on_boot.priority` options but merge the `esphome.on_boot.then` lists. This is unexpected. Even if the user specifies `esphome.on_boot` as list this list might get overwritten.

The behaviour when `esphome.on_boot` is a list is much nicher. It will allow multiple packages to define their on_boot hooks with their own priority.

Ref: https://github.com/esphome/esphome-docs/pull/4557
Ref: https://esphome.io/components/esphome.html#on-boot