### PR TITLE
IPv6 for airgradient-one

### DIFF
--- a/airgradient-one.yaml
+++ b/airgradient-one.yaml
@@ -13,6 +13,9 @@ ota:  # Add password as desired
   platform: esphome
   # password:
 
+network:
+    enable_ipv6: true
+
 wifi:
 
 dashboard_import:


### PR DESCRIPTION
I tested this on  o-1pst, no issues discovered. It does not dupport DHCPv6, only SLAAC, but I would like to understand what does and does not work on IPv6 on my network, so I can slowly move to mostly IPv6.

Hope that's ok and not too risky for you.