### PR TITLE
Enable IPv6 for o-1pst

### DIFF
--- a/airgradient-open-air-o-1pst.yaml
+++ b/airgradient-open-air-o-1pst.yaml
@@ -14,6 +14,9 @@ ota:  # Add password as desired
   platform: esphome
   # password:
 
+network:
+    enable_ipv6: true
+
 wifi:
 
 dashboard_import:


### PR DESCRIPTION
I tested this on  o-1pst, no issues discovered. It does not dupport DHCPv6, only SLAAC, but I would like to understand what does and does not work on IPv6 on my network, so I can slowly move to mostly IPv6.

Hope that's ok and not too risky for you.