### PR TITLE
Fix pms5003t extended life typo

### DIFF
--- a/packages/sensor_pms5003t_extended_life.yaml
+++ b/packages/sensor_pms5003t_extended_life.yaml
@@ -10,7 +10,7 @@ sensor:
     type: PMS5003T
     uart_id: pms5003_uart
     pm_2_5:
-      name: "PM 2.5"
+      name: "PM 2.5 Raw"
       id: pm_2_5_raw
       device_class: pm25  # Added to report properly to HomeKit
       disabled_by_default: true


### PR DESCRIPTION
Upon updating to ESPHome 2025.7.0 from 2025.6.3, my AirGradient Open Air O-1PST was failing to update today due to the following error:
`Duplicate sensor entity with name 'PM 2.5' found. Each entity must have a unique name within its platform across all devices.` I thought this was odd since my two AirGradient Ones updated just fine.

I know very little about ESPHome, but the pm_2_5_raw id in `sensor_pms5003t_extended_life.yaml` is named "PM 2.5", which is repeated later in the yaml. Comparing to `sensor_pms5003_extended_life.yaml`, I don't see the same typo, so I went ahead and updated `sensor_pms5003t_extended_life.yaml` to match.

Saved this locally on my HomeAssistant instance and was able to update to 2025.7.0 successfully. PM2.5 readings appear to be working as expected.

I've never contributed to a public repo before, but I hope this might help others!