### PR TITLE
Fix NowCast weight_factor calculation

### DIFF
--- a/packages/sensor_nowcast_aqi.yaml
+++ b/packages/sensor_nowcast_aqi.yaml
@@ -221,7 +221,7 @@ script:
             // Calculate the weight factor
             float range = max - min;
             float rate = range / max;
-            float weight_factor = 1.0 - range;
+            float weight_factor = 1.0 - rate;
             if (weight_factor < 0.5) {
               weight_factor = 0.5;
             } else if (weight_factor > 1.0) {
@@ -274,7 +274,7 @@ script:
             // Calculate the weight factor
             float range = max - min;
             float rate = range / max;
-            float weight_factor = 1.0 - range;
+            float weight_factor = 1.0 - rate;
             if (weight_factor < 0.5) {
               weight_factor = 0.5;
             } else if (weight_factor > 1.0) {


### PR DESCRIPTION
Not sure how I never noticed this in my original code. `weight_factor` is supposed to be based on the rate of change, not the range itself. This fix should make the NowCast calculation slightly more accurate.

> [!NOTE]
> I found this while finally getting around to transcribing these calculations to a home assistant SQL sensor query
> (better late than never).