### PR TITLE
Add commented out block to simplify setting default temperature display unit

### DIFF
--- a/airgradient-basic.yaml
+++ b/airgradient-basic.yaml
@@ -31,3 +31,10 @@ packages:
   airgradient_api: github://MallocArray/airgradient_esphome/packages/airgradient_api_d1_mini_no_sgp41.yaml
   wifi: github://MallocArray/airgradient_esphome/packages/sensor_wifi.yaml
   uptime: github://MallocArray/airgradient_esphome/packages/sensor_uptime.yaml
+
+# Uncomment this block to default to displaying in Celsius
+#switch:
+#- platform: template
+#  id: !extend display_in_f
+#  restore_mode: RESTORE_DEFAULT_OFF
+#  optimistic: True

--- a/airgradient-one.yaml
+++ b/airgradient-one.yaml
@@ -39,3 +39,10 @@ binary_sensor:
   - id: !extend config_button
     pin:
       ignore_strapping_warning: true  # Acknowledging that this is a strapping pin and should not have external pullup/down resistors  https://esphome.io/guides/faq.html#why-am-i-getting-a-warning-about-strapping-pins
+
+# Uncomment this block to default to displaying in Celsius
+#switch:
+#- platform: template
+#  id: !extend display_in_f
+#  restore_mode: RESTORE_DEFAULT_OFF
+#  optimistic: True

--- a/airgradient-pro.yaml
+++ b/airgradient-pro.yaml
@@ -37,3 +37,10 @@ binary_sensor:
   - id: !extend config_button
     pin:
       number: D7
+
+# Uncomment this block to default to displaying in Celsius
+#switch:
+#- platform: template
+#  id: !extend display_in_f
+#  restore_mode: RESTORE_DEFAULT_OFF
+#  optimistic: True


### PR DESCRIPTION
Had this thought when I saw #131 

I feel like when I was first learning esphome this type of config was hard as I wasn't familiar with using `extend`. I think some common example configs that the user may want to override could be helpful for on-boarding new users and for existing users it still simplifies it if they want to change a default that a decent number of users will want changed.

Even if #131 is merged in the opposite version of this PR with it set to `RESTORE_DEFAULT_ON` would be good.