### PR TITLE
Add support for lolin c3 mini on a airgradient-pro

### DIFF
--- a/airgradient-pro.yaml
+++ b/airgradient-pro.yaml
@@ -21,6 +21,7 @@ dashboard_import:
 
 packages:
   board: github://MallocArray/airgradient_esphome/packages/airgradient_d1_mini_board.yaml
+  # board: github://MallocArray/airgradient_esphome/packages/airgradient_lolin-c3-mini_board.yaml
   captive_portal: github://MallocArray/airgradient_esphome/packages/captive_portal.yaml
   pm_2.5: github://MallocArray/airgradient_esphome/packages/sensor_pms5003.yaml
   co2: github://MallocArray/airgradient_esphome/packages/sensor_s8.yaml
@@ -33,7 +34,13 @@ packages:
   wifi: github://MallocArray/airgradient_esphome/packages/sensor_wifi.yaml
   uptime: github://MallocArray/airgradient_esphome/packages/sensor_uptime.yaml
 
+# For use with the D1 Board
 binary_sensor:
   - id: !extend config_button
     pin:
       number: D7
+
+# For use with the Lolin C3 Mini Board
+# binary_sensor:
+#   - id: !extend config_button
+#     pin: 4

--- a/packages/airgradient_lolin-c3-mini_board.yaml
+++ b/packages/airgradient_lolin-c3-mini_board.yaml
@@ -1,0 +1,48 @@
+# This is for use with the AirGradient Pro replacing the default
+# D1 Mini esp8266 board with a Lolin C3 Mini esp32 board
+
+substitutions:
+  config_version: 5.3.2
+
+esphome:
+  name: "${name}"
+  friendly_name: "${friendly_name}"
+  name_add_mac_suffix: ${name_add_mac_suffix}  # Set to false if you don't want part of the MAC address in the name
+  platform: ESP32
+
+  project:
+    name: mallocarray.airgradient
+    version: "$config_version"
+  min_version: 2025.5.0
+
+esp32:
+  board: lolin_c3_mini
+  variant: esp32c3
+  framework:
+    type: esp-idf
+
+# Enable logging
+# https://esphome.io/components/logger.html
+logger:
+
+uart:
+  - rx_pin: 1
+    tx_pin: 0
+    baud_rate: 9600
+    id: pms5003_uart
+
+  - rx_pin: 6
+    tx_pin: 7
+    baud_rate: 9600
+    id: senseair_co2_uart
+
+i2c:
+  # https://esphome.io/components/i2c.html
+  sda:
+    number: 8
+    # Acknowledging that this is a strapping pin and should not have external pullup/down resistors
+    # https://esphome.io/guides/faq.html#why-am-i-getting-a-warning-about-strapping-pins
+    ignore_strapping_warning: true
+  scl: 10
+  # 400kHz eliminates warnings about components taking a long time other than SGP40 component: https://github.com/esphome/issues/issues/4717
+  frequency: 400kHz


### PR DESCRIPTION
This is for using the lolin C3 Mini as a drop in replacement of the D1 on the airgradient pro.

## Testing

I've been testing this for several days without issue on 2 airgradient pro v4.2 boards.

## References

Used info from multiple comments in this thread to enable the config locally and then ported it to look like the configs in the current repo:

https://forum.airgradient.com/t/new-wemos-board/251

(replacing #173 for keeping my main branch sync-ed with this repo)