### PR TITLE
Flip the PMS5003 uart pins on AG Basic

### DIFF
--- a/airgradient-basic.yaml
+++ b/airgradient-basic.yaml
@@ -6,6 +6,7 @@ substitutions:
   name: "ag-basic"
   friendly_name: "AG Basic"
   name_add_mac_suffix: "false"  # Must have quotes around value
+  flip_pms5003_uart_pins: True
 
 # Enable Home Assistant API
 api:  # Add encryption key as desired

--- a/packages/airgradient_d1_mini_board.yaml
+++ b/packages/airgradient_d1_mini_board.yaml
@@ -1,5 +1,6 @@
 substitutions:
   config_version: 5.3.3
+  flip_pms5003_uart_pins: False
 
 esphome:
   name: "${name}"
@@ -26,8 +27,8 @@ uart:
     baud_rate: 9600
     id: senseair_co2_uart
 
-  - rx_pin: D5
-    tx_pin: D6
+  - rx_pin: ${"D6" if flip_pms5003_uart_pins else "D5"}
+    tx_pin: ${"D5" if flip_pms5003_uart_pins else "D6"}
     baud_rate: 9600
     id: pms5003_uart
 


### PR DESCRIPTION
Some Airgradient models come with the RX and TX UART pins for the PMS5003 swapped. Example: https://www.airgradient.com/documentation/diy-outdoor/ has them flipped compared to the one currently configured in this repository (example:  https://www.airgradient.com/documentation/diy-pro-v42/).

This PR adds a way to configure this flipping and enables it for the basic model.