### PR TITLE
Fix PM2.5 correction float divisions

### DIFF
--- a/full_config/ag-basic.yaml
+++ b/full_config/ag-basic.yaml
@@ -203,11 +203,11 @@ sensor:
       } else if (pm_2_5_calibrated < 30.0) {
         result = (0.524 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 50.0) {
-        result = (0.786 * (pm_2_5_calibrated / 20 - 3/2) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3/2))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
+        result = (0.786 * (pm_2_5_calibrated / 20 - 3.0/2.0) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3.0/2.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 210.0) {
         result = (0.786 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 260.0) {
-        result = (0.69 * (pm_2_5_calibrated / 50 - 21/5) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21/5))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (2.966 * (pm_2_5_calibrated / 50 - 21/5)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21/5));
+        result = (0.69 * (pm_2_5_calibrated / 50 - 21.0/5.0) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (2.966 * (pm_2_5_calibrated / 50 - 21.0/5.0)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21.0/5.0));
       } else {
         result = 2.966 + (0.69 * pm_2_5_calibrated) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2));
       }

--- a/full_config/ag-one.yaml
+++ b/full_config/ag-one.yaml
@@ -234,11 +234,11 @@ sensor:
       } else if (pm_2_5_calibrated < 30.0) {
         result = (0.524 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 50.0) {
-        result = (0.786 * (pm_2_5_calibrated / 20 - 3/2) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3/2))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
+        result = (0.786 * (pm_2_5_calibrated / 20 - 3.0/2.0) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3.0/2.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 210.0) {
         result = (0.786 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 260.0) {
-        result = (0.69 * (pm_2_5_calibrated / 50 - 21/5) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21/5))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (2.966 * (pm_2_5_calibrated / 50 - 21/5)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21/5));
+        result = (0.69 * (pm_2_5_calibrated / 50 - 21.0/5.0) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (2.966 * (pm_2_5_calibrated / 50 - 21.0/5.0)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21.0/5.0));
       } else {
         result = 2.966 + (0.69 * pm_2_5_calibrated) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2));
       }

--- a/full_config/ag-open-air-o-1ppt.yaml
+++ b/full_config/ag-open-air-o-1ppt.yaml
@@ -279,11 +279,11 @@ sensor:
       } else if (pm_2_5_calibrated < 30.0) {
         result = (0.524 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 50.0) {
-        result = (0.786 * (pm_2_5_calibrated / 20 - 3/2) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3/2))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
+        result = (0.786 * (pm_2_5_calibrated / 20 - 3.0/2.0) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3.0/2.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 210.0) {
         result = (0.786 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 260.0) {
-        result = (0.69 * (pm_2_5_calibrated / 50 - 21/5) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21/5))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (2.966 * (pm_2_5_calibrated / 50 - 21/5)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21/5));
+        result = (0.69 * (pm_2_5_calibrated / 50 - 21.0/5.0) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (2.966 * (pm_2_5_calibrated / 50 - 21.0/5.0)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21.0/5.0));
       } else {
         result = 2.966 + (0.69 * pm_2_5_calibrated) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2));
       }
@@ -454,11 +454,11 @@ sensor:
       } else if (pm_2_5_calibrated < 30.0) {
         result = (0.524 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 50.0) {
-        result = (0.786 * (pm_2_5_calibrated / 20 - 3/2) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3/2))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
+        result = (0.786 * (pm_2_5_calibrated / 20 - 3.0/2.0) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3.0/2.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 210.0) {
         result = (0.786 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 260.0) {
-        result = (0.69 * (pm_2_5_calibrated / 50 - 21/5) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21/5))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (2.966 * (pm_2_5_calibrated / 50 - 21/5)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21/5));
+        result = (0.69 * (pm_2_5_calibrated / 50 - 21.0/5.0) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (2.966 * (pm_2_5_calibrated / 50 - 21.0/5.0)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21.0/5.0));
       } else {
         result = 2.966 + (0.69 * pm_2_5_calibrated) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2));
       }

--- a/full_config/ag-open-air-o-1pst.yaml
+++ b/full_config/ag-open-air-o-1pst.yaml
@@ -280,11 +280,11 @@ sensor:
       } else if (pm_2_5_calibrated < 30.0) {
         result = (0.524 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 50.0) {
-        result = (0.786 * (pm_2_5_calibrated / 20 - 3/2) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3/2))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
+        result = (0.786 * (pm_2_5_calibrated / 20 - 3.0/2.0) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3.0/2.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 210.0) {
         result = (0.786 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 260.0) {
-        result = (0.69 * (pm_2_5_calibrated / 50 - 21/5) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21/5))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (2.966 * (pm_2_5_calibrated / 50 - 21/5)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21/5));
+        result = (0.69 * (pm_2_5_calibrated / 50 - 21.0/5.0) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (2.966 * (pm_2_5_calibrated / 50 - 21.0/5.0)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21.0/5.0));
       } else {
         result = 2.966 + (0.69 * pm_2_5_calibrated) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2));
       }

--- a/full_config/ag-pro.yaml
+++ b/full_config/ag-pro.yaml
@@ -205,11 +205,11 @@ sensor:
       } else if (pm_2_5_calibrated < 30.0) {
         result = (0.524 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 50.0) {
-        result = (0.786 * (pm_2_5_calibrated / 20 - 3/2) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3/2))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
+        result = (0.786 * (pm_2_5_calibrated / 20 - 3.0/2.0) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3.0/2.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 210.0) {
         result = (0.786 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 260.0) {
-        result = (0.69 * (pm_2_5_calibrated / 50 - 21/5) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21/5))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (2.966 * (pm_2_5_calibrated / 50 - 21/5)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21/5));
+        result = (0.69 * (pm_2_5_calibrated / 50 - 21.0/5.0) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (2.966 * (pm_2_5_calibrated / 50 - 21.0/5.0)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21.0/5.0));
       } else {
         result = 2.966 + (0.69 * pm_2_5_calibrated) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2));
       }

--- a/packages/sensor_pms5003.yaml
+++ b/packages/sensor_pms5003.yaml
@@ -61,11 +61,11 @@ sensor:
       } else if (pm_2_5_calibrated < 30.0) {
         result = (0.524 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 50.0) {
-        result = (0.786 * (pm_2_5_calibrated / 20 - 3/2) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3/2))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
+        result = (0.786 * (pm_2_5_calibrated / 20 - 3.0/2.0) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3.0/2.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 210.0) {
         result = (0.786 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 260.0) {
-        result = (0.69 * (pm_2_5_calibrated / 50 - 21/5) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21/5))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (2.966 * (pm_2_5_calibrated / 50 - 21/5)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21/5));
+        result = (0.69 * (pm_2_5_calibrated / 50 - 21.0/5.0) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (2.966 * (pm_2_5_calibrated / 50 - 21.0/5.0)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21.0/5.0));
       } else {
         result = 2.966 + (0.69 * pm_2_5_calibrated) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2));
       }

--- a/packages/sensor_pms5003_extended_life.yaml
+++ b/packages/sensor_pms5003_extended_life.yaml
@@ -60,11 +60,11 @@ sensor:
       } else if (pm_2_5_calibrated < 30.0) {
         result = (0.524 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 50.0) {
-        result = (0.786 * (pm_2_5_calibrated / 20 - 3/2) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3/2))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
+        result = (0.786 * (pm_2_5_calibrated / 20 - 3.0/2.0) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3.0/2.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 210.0) {
         result = (0.786 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 260.0) {
-        result = (0.69 * (pm_2_5_calibrated / 50 - 21/5) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21/5))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (2.966 * (pm_2_5_calibrated / 50 - 21/5)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21/5));
+        result = (0.69 * (pm_2_5_calibrated / 50 - 21.0/5.0) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (2.966 * (pm_2_5_calibrated / 50 - 21.0/5.0)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21.0/5.0));
       } else {
         result = 2.966 + (0.69 * pm_2_5_calibrated) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2));
       }

--- a/packages/sensor_pms5003t.yaml
+++ b/packages/sensor_pms5003t.yaml
@@ -92,11 +92,11 @@ sensor:
       } else if (pm_2_5_calibrated < 30.0) {
         result = (0.524 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 50.0) {
-        result = (0.786 * (pm_2_5_calibrated / 20 - 3/2) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3/2))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
+        result = (0.786 * (pm_2_5_calibrated / 20 - 3.0/2.0) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3.0/2.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 210.0) {
         result = (0.786 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 260.0) {
-        result = (0.69 * (pm_2_5_calibrated / 50 - 21/5) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21/5))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (2.966 * (pm_2_5_calibrated / 50 - 21/5)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21/5));
+        result = (0.69 * (pm_2_5_calibrated / 50 - 21.0/5.0) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (2.966 * (pm_2_5_calibrated / 50 - 21.0/5.0)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21.0/5.0));
       } else {
         result = 2.966 + (0.69 * pm_2_5_calibrated) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2));
       }

--- a/packages/sensor_pms5003t_2.yaml
+++ b/packages/sensor_pms5003t_2.yaml
@@ -89,11 +89,11 @@ sensor:
       } else if (pm_2_5_calibrated < 30.0) {
         result = (0.524 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 50.0) {
-        result = (0.786 * (pm_2_5_calibrated / 20 - 3/2) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3/2))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
+        result = (0.786 * (pm_2_5_calibrated / 20 - 3.0/2.0) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3.0/2.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 210.0) {
         result = (0.786 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 260.0) {
-        result = (0.69 * (pm_2_5_calibrated / 50 - 21/5) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21/5))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (2.966 * (pm_2_5_calibrated / 50 - 21/5)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21/5));
+        result = (0.69 * (pm_2_5_calibrated / 50 - 21.0/5.0) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (2.966 * (pm_2_5_calibrated / 50 - 21.0/5.0)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21.0/5.0));
       } else {
         result = 2.966 + (0.69 * pm_2_5_calibrated) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2));
       }

--- a/packages/sensor_pms5003t_2_extended_life.yaml
+++ b/packages/sensor_pms5003t_2_extended_life.yaml
@@ -92,11 +92,11 @@ sensor:
       } else if (pm_2_5_calibrated < 30.0) {
         result = (0.524 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 50.0) {
-        result = (0.786 * (pm_2_5_calibrated / 20 - 3/2) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3/2))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
+        result = (0.786 * (pm_2_5_calibrated / 20 - 3.0/2.0) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3.0/2.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 210.0) {
         result = (0.786 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 260.0) {
-        result = (0.69 * (pm_2_5_calibrated / 50 - 21/5) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21/5))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (2.966 * (pm_2_5_calibrated / 50 - 21/5)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21/5));
+        result = (0.69 * (pm_2_5_calibrated / 50 - 21.0/5.0) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (2.966 * (pm_2_5_calibrated / 50 - 21.0/5.0)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21.0/5.0));
       } else {
         result = 2.966 + (0.69 * pm_2_5_calibrated) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2));
       }

--- a/packages/sensor_pms5003t_extended_life.yaml
+++ b/packages/sensor_pms5003t_extended_life.yaml
@@ -92,11 +92,11 @@ sensor:
       } else if (pm_2_5_calibrated < 30.0) {
         result = (0.524 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 50.0) {
-        result = (0.786 * (pm_2_5_calibrated / 20 - 3/2) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3/2))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
+        result = (0.786 * (pm_2_5_calibrated / 20 - 3.0/2.0) + 0.524 * (1 - (pm_2_5_calibrated / 20 - 3.0/2.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 210.0) {
         result = (0.786 * pm_2_5_calibrated) - (0.0862 * id(humidity_raw).state) + 5.75;
       } else if (pm_2_5_calibrated < 260.0) {
-        result = (0.69 * (pm_2_5_calibrated / 50 - 21/5) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21/5))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (2.966 * (pm_2_5_calibrated / 50 - 21/5)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21/5))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21/5));
+        result = (0.69 * (pm_2_5_calibrated / 50 - 21.0/5.0) + 0.786 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) * pm_2_5_calibrated - (0.0862 * id(humidity_raw).state * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (2.966 * (pm_2_5_calibrated / 50 - 21.0/5.0)) + (5.75 * (1 - (pm_2_5_calibrated / 50 - 21.0/5.0))) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2) * (pm_2_5_calibrated / 50 - 21.0/5.0));
       } else {
         result = 2.966 + (0.69 * pm_2_5_calibrated) + (8.84 * pow(10,-4) * pow(pm_2_5_calibrated,2));
       }


### PR DESCRIPTION
The PM2.5 correction lambda was doing integer division in a couple of places (e.g., 3/2 and 21/5), which silently truncates and slightly skews the correction math. I changed those divisions to explicit floats (3.0/2.0, 21.0/5.0) so the calculations use proper fractional values. This fixes the correction curve without changing any other behavior.