### PR TITLE
fix(display): use dash in Temp/Hum page

### DIFF
--- a/full_config/ag-one.yaml
+++ b/full_config/ag-one.yaml
@@ -499,7 +499,7 @@ switch:
     disabled_by_default: false
     assumed_state: false
   - platform: template
-    name: Display Temp/Hum Page
+    name: Display Temp-Hum Page
     id: display_air_temp_page
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: true

--- a/packages/display_sh1106_multi_page.yaml
+++ b/packages/display_sh1106_multi_page.yaml
@@ -280,7 +280,7 @@ switch:
     icon: "mdi:monitor"
 
   - platform: template
-    name: "Display Temp/Hum Page"
+    name: "Display Temp-Hum Page"
     id: display_air_temp_page
     restore_mode: RESTORE_DEFAULT_OFF
     optimistic: True


### PR DESCRIPTION
ESPHome reserves '/' for URL path separators and warns that this
name will become an error in 2026.7.0.

ESPHome recommends the "Unicode Fraction Slash"; however, this may
cause confusion as it is visually similar. Use a '-' instead to
reduce potential confusion.

Fixes: #183