### PR TITLE
Rename now-reserved AQI sensor ID

### DIFF
--- a/packages/sensor_nowcast_aqi.yaml
+++ b/packages/sensor_nowcast_aqi.yaml
@@ -36,7 +36,7 @@ text_sensor:
 
 sensor:
   - platform: template
-    id: aqi
+    id: aqi_epa_outdoor
     name: "AQI"
     device_class: aqi
     icon: "mdi:weather-windy-variant"


### PR DESCRIPTION
It seems that the id `aqi` is now reserved by ESPHome:

`ID 'aqi' conflicts with the name of an esphome integration, please use another ID name.`

https://esphome.io/components/sensor/aqi/

I was hoping they'd have integrated proper AQI/NowCast integration into ESPHome itself but the docs say it's "instantaneous." I really need to make some time and finish the SQL query to get this added as a regular sensor in Home Assistant itself.