### PR TITLE
Fix aqi_epa_outdoor id name introduced in #198

### DIFF
--- a/packages/sensor_nowcast_aqi.yaml
+++ b/packages/sensor_nowcast_aqi.yaml
@@ -200,7 +200,7 @@ script:
 
           int aqi_calc = std::max(aqi_2_5, aqi_10_0);
           if (aqi_calc > 0) {
-            id(aqi).publish_state(aqi_calc);
+            id(aqi_epa_outdoor).publish_state(aqi_calc);
             // Just in case we're counting down, make sure we set to zero
             if (isnan(id(aqi_delay_mins)) || id(aqi_delay_mins) > 0) {
               id(aqi_delay_mins) = 0;


### PR DESCRIPTION
It looks like I missed a reference to the `aqi` id in #198. This should fix build issues.