### PR TITLE
Fix display_blank_page not showing only the blank page

### DIFF
--- a/packages/display_sh1106_multi_page.yaml
+++ b/packages/display_sh1106_multi_page.yaml
@@ -224,7 +224,9 @@ display:
               # Only change pages if a page switch for a non-blank page is actually enabled;
               # acts as a base case to prevent recursive page change loop
               condition:
-                binary_sensor.is_on: any_non_blank_page_enabled
+                and:
+                  - switch.is_off: display_blank_page
+                  - binary_sensor.is_on: any_non_blank_page_enabled
               then:
                 - display.page.show_next: oled_display
                 - component.update: oled_display

--- a/packages/display_sh1106_single_page.yaml
+++ b/packages/display_sh1106_single_page.yaml
@@ -89,7 +89,9 @@ display:
               # Only change pages if a page switch for a non-blank page is actually enabled;
               # acts as a base case to prevent recursive page change loop
               condition:
-                binary_sensor.is_on: any_non_blank_page_enabled
+                and:
+                  - switch.is_off: display_blank_page
+                  - binary_sensor.is_on: any_non_blank_page_enabled
               then:
                 - display.page.show_next: oled_display
                 - component.update: oled_display


### PR DESCRIPTION
Previously, switching to blank triggered on_page_change -> blank, which always jumped to show_next whenever any non-blank page was enabled. Now that jump is gated by switch.is_off: display_blank_page, so enabling display_blank_page keeps the screen blank as intended.